### PR TITLE
Resize image height/width attrs, and fix typos

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,6 +13,7 @@ const taxonomy = require('#/taxonomy');
 const time = require('#/time');
 const type = require('#/type');
 const utils = require('#/utils');
+const images = require('#/images');
 
 module.exports = (eleventyConfig) => {
   eleventyConfig.setUseGitIgnore(false);
@@ -108,7 +109,9 @@ module.exports = (eleventyConfig) => {
   eleventyConfig.addFilter('mdInline', type.mdInline);
   eleventyConfig.addFilter('removeMd', type.removeMd);
   eleventyConfig.addFilter('elide', type.elide);
-  eleventyConfig.addFilter('imgSuffix', utils.imgSuffix);
+
+  eleventyConfig.addFilter('imgSuffix', images.imgSuffix);
+  eleventyConfig.addFilter('imgSize', images.imgSize);
 
   eleventyConfig.addFilter('max', (array) => Math.max(...array));
 

--- a/content/_data/taxonomy.yaml
+++ b/content/_data/taxonomy.yaml
@@ -38,6 +38,12 @@ img:
     - 2240
   # named `sizes` for smaller images
   sizes:
-    media: '(min-width: 80em) 15vw, (min-width: 40em) 30vw, 100vw'
-    card: '(min-width: 95em) 30vw, (min-width: 56em) 45vw, 100vw'
-    gallery: '(min-width: 95em) 30vw, 50vw'
+    media:
+      html: '(min-width: 80em) 15vw, (min-width: 40em) 30vw, 100vw'
+      fallback: 960
+    card:
+      html: '(min-width: 95em) 30vw, (min-width: 56em) 45vw, 100vw'
+      fallback: 960
+    gallery:
+      html: '(min-width: 95em) 30vw, 50vw'
+      fallback: 1280

--- a/content/_includes/embed.macros.njk
+++ b/content/_includes/embed.macros.njk
@@ -387,7 +387,7 @@ params:
   {%- set respSrc = src | imgSuffix(fallback or config.fallback) -%}
   {%- set configSizes = config.sizes[sizes].html if config.sizes[sizes] else none -%}
 {%- endif -%}
-{% set resize = width | imgSize(height, sizes) %}
+{%- set resize = width | imgSize(height, sizes) -%}
 {%- set attrs = attrs | merge({
   'src': respSrc or src,
   'alt': alt,

--- a/content/_includes/embed.macros.njk
+++ b/content/_includes/embed.macros.njk
@@ -319,7 +319,7 @@ params:
 
 {# @docs
 label: srcset
-cateogry: Embed
+category: Embed
 note: Generate a `srcset` attribute for responsive images
 params:
   src:
@@ -385,12 +385,13 @@ params:
   {%- set imgSrcSet = imgSrcSet if (imgSrcSet != "") else none -%}
   {%- set respSrc = src | imgSuffix(config.fallback) -%}
 {%- endif -%}
+{% set resize = width | imgSize(height) %}
 {%- set attrs = attrs | merge({
   'src': respSrc or src,
   'alt': alt,
   'srcset': imgSrcSet,
-  'width': width,
-  'height': height,
+  'width': resize.width,
+  'height': resize.height,
   'sizes': (config.sizes[sizes] or sizes) if imgSrcSet else none
 }) -%}
 <img {{ utility.show_attrs(attrs) }}/>

--- a/content/_includes/embed.macros.njk
+++ b/content/_includes/embed.macros.njk
@@ -380,19 +380,21 @@ params:
 {%- if src -%}
 {%- set config = 'img' | fromTaxonomy -%}
 {%- if not ('://' in src) -%}
+  {%- set fallback = config.sizes[sizes].fallback if config.sizes[sizes] else none -%}
   {%- set src = ('/assets/images/' + src) -%}
   {%- set imgSrcSet = srcset(src, width) -%}
   {%- set imgSrcSet = imgSrcSet if (imgSrcSet != "") else none -%}
-  {%- set respSrc = src | imgSuffix(config.fallback) -%}
+  {%- set respSrc = src | imgSuffix(fallback or config.fallback) -%}
+  {%- set configSizes = config.sizes[sizes].html if config.sizes[sizes] else none -%}
 {%- endif -%}
-{% set resize = width | imgSize(height) %}
+{% set resize = width | imgSize(height, sizes) %}
 {%- set attrs = attrs | merge({
   'src': respSrc or src,
   'alt': alt,
   'srcset': imgSrcSet,
   'width': resize.width,
   'height': resize.height,
-  'sizes': (config.sizes[sizes] or sizes) if imgSrcSet else none
+  'sizes': configSizes or sizes
 }) -%}
 <img {{ utility.show_attrs(attrs) }}/>
 {%- endif -%}

--- a/content/index.md
+++ b/content/index.md
@@ -106,9 +106,10 @@ along with refactors for **integrated design systems,
 accessibility, performance,
 and long-term sustainability**.
 
-Since then OddBird has become an industry leaders --
+Since then OddBird has become an industry leader --
 from our work on Django, Sass, and Susy,
-to the **Mozilla Developer Channel**,
+to the Mozilla Developer Channel,
+**CSS Working Group**,
 and in-depth **trainings on front-end architecture, workflow,
 component libraries, testing, and documentation**.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@
 const gulp = require('gulp');
 const responsive = require('gulp-responsive');
 
-const { responsiveConfig } = require('#/type');
+const { responsiveConfig } = require('#/images');
 
 gulp.task('images', () =>
   gulp

--- a/src/filters/images.js
+++ b/src/filters/images.js
@@ -43,16 +43,21 @@ params:
     type: number
     default: null
 */
-const imgSize = (width = null, height = null) => {
-  const fallback = taxonomy.img.fallback;
-  const size = { width, height };
+const imgSize = (width = null, height = null, size) => {
+  const img = { width, height };
+  const explicitSize = taxonomy.img.sizes[size]
+    ? taxonomy.img.sizes[size].fallback
+    : size;
+
+  const fallback =
+    typeof explicitSize === 'number' ? explicitSize : taxonomy.img.fallback;
 
   if (width && width > fallback) {
-    size.width = fallback;
-    size.height = height ? Math.round((fallback / width) * height) : height;
+    img.width = fallback;
+    img.height = height ? Math.round((fallback / width) * height) : height;
   }
 
-  return size;
+  return img;
 };
 
 module.exports = {

--- a/src/filters/images.js
+++ b/src/filters/images.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { taxonomy } = require('#/taxonomy');
+
+const responsiveConfig = taxonomy.img.srcset.map((size) => ({
+  width: size,
+  rename: {
+    suffix: `-${size}`,
+  },
+}));
+
+/* @docs
+label: imgSuffix
+category: responsive images
+note: Add img suffix for responsiveness
+example: |
+  <img srcset="{{ src | imgSuffix('320') }} 320w" />
+params:
+  imgSrc:
+    type: string
+  suffix:
+    type: string | number
+*/
+const imgSuffix = (imgSrc, suffix) => {
+  const idx = imgSrc.lastIndexOf('.');
+  const imgPath = imgSrc.substring(0, idx);
+  const ext = imgSrc.substring(idx + 1);
+  return `${imgPath}-${suffix}.${ext}`;
+};
+
+/* @docs
+label: imgSize
+category: responsive images
+note: Resize image height/width attributes to match output
+example: |
+  {% set size = img.width | imgSize(img.height) %}
+  <img src="..." width="{{ size.width }}" height="{{ size.height }}" />
+params:
+  width:
+    type: number
+    default: null
+  height:
+    type: number
+    default: null
+*/
+const imgSize = (width = null, height = null) => {
+  const fallback = taxonomy.img.fallback;
+  const size = { width, height };
+
+  if (width && width > fallback) {
+    size.width = fallback;
+    size.height = height ? Math.round((fallback / width) * height) : height;
+  }
+
+  return size;
+};
+
+module.exports = {
+  imgSize,
+  imgSuffix,
+  responsiveConfig,
+};

--- a/src/filters/type.js
+++ b/src/filters/type.js
@@ -10,14 +10,7 @@ const truncate = require('truncate-html');
 const type = require('typogr');
 const markdownItResponsive = require('@gerhobbelt/markdown-it-responsive');
 
-const { taxonomy } = require('#/taxonomy');
-
-const responsiveConfig = taxonomy.img.srcset.map((size) => ({
-  width: size,
-  rename: {
-    suffix: `-${size}`,
-  },
-}));
+const { responsiveConfig } = require('#/images');
 
 const imgConf = {
   responsive: {
@@ -165,5 +158,4 @@ module.exports = {
   mdInline,
   removeMd,
   heading,
-  responsiveConfig,
 };

--- a/src/filters/utils.js
+++ b/src/filters/utils.js
@@ -45,23 +45,4 @@ const styles = (dict) =>
     .map((val, prop) => (val ? `${prop}:${val};` : ''))
     .reduce((all, one) => `${all}${one}`, '');
 
-/* @docs
-label: imgSuffix
-category: images
-note: Add img suffix for responsiveness
-example: |
-  <img srcset="{{ src | imgSuffix('320') }} 320w" />
-params:
-  imgSrc:
-    type: string
-  suffix:
-    type: string | number
-*/
-const imgSuffix = (imgSrc, suffix) => {
-  const idx = imgSrc.lastIndexOf('.');
-  const imgPath = imgSrc.substring(0, idx);
-  const ext = imgSrc.substring(idx + 1);
-  return `${imgPath}-${suffix}.${ext}`;
-};
-
-module.exports = { typeCheck, styles, imgSuffix };
+module.exports = { typeCheck, styles };

--- a/test/js/images.test.js
+++ b/test/js/images.test.js
@@ -1,0 +1,44 @@
+const { imgSize, imgSuffix } = require('#/images');
+
+describe('utility filters', () => {
+  test('imgSuffix', () => {
+    const image = 'birds/carl.jpg';
+    const expected = 'birds/carl-550.jpg';
+
+    expect(imgSuffix(image, 550)).toEqual(expected);
+  });
+
+  describe('imgSize', () => {
+    test('returns an object with width & height properties', () => {
+      expect(imgSize()).toEqual({ width: null, height: null });
+    });
+
+    test('scales width down to responsive-image fallback', () => {
+      expect(imgSize(3000)).toEqual({
+        width: 1280,
+        height: null,
+      });
+    });
+
+    test('scales height accordingly', () => {
+      expect(imgSize(2560, 1000)).toEqual({
+        width: 1280,
+        height: 500,
+      });
+    });
+
+    test('does not scale up', () => {
+      expect(imgSize(200, 100)).toEqual({
+        width: 200,
+        height: 100,
+      });
+    });
+
+    test('rounds re-calculated height', () => {
+      expect(imgSize(4410, 2159)).toEqual({
+        width: 1280,
+        height: 627,
+      });
+    });
+  });
+});

--- a/test/js/images.test.js
+++ b/test/js/images.test.js
@@ -27,6 +27,24 @@ describe('utility filters', () => {
       });
     });
 
+    test('takes size into account', () => {
+      expect(imgSize(2880, 3000, 960)).toEqual({
+        width: 960,
+        height: 1000,
+      });
+      expect(imgSize(2880, 3000, 'media')).toEqual({
+        width: 960,
+        height: 1000,
+      });
+    });
+
+    test('ignores unknown size', () => {
+      expect(imgSize(2880, 3000, 'nothing-ever')).toEqual({
+        width: 1280,
+        height: 1333,
+      });
+    });
+
     test('does not scale up', () => {
       expect(imgSize(200, 100)).toEqual({
         width: 200,

--- a/test/js/utils.test.js
+++ b/test/js/utils.test.js
@@ -1,4 +1,4 @@
-const { typeCheck, styles, imgSuffix } = require('#/utils');
+const { typeCheck, styles } = require('#/utils');
 
 describe('utility filters', () => {
   test('typeCheck', () => {
@@ -13,12 +13,5 @@ describe('utility filters', () => {
 
     expect(styles(testStyles)).toEqual(expected);
     expect(styles(emptyStyles)).toEqual('');
-  });
-
-  test('imgSuffix', () => {
-    const image = 'birds/carl.jpg';
-    const expected = 'birds/carl-550.jpg';
-
-    expect(imgSuffix(image, 550)).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of animals._

![mouse in a shoe](http://www.hdnicewallpapers.com/Walls/Big/Mouse/Beautiful_Cute_Mouse_in_Shoes_Wallpaper_Free_Download.jpg)

## Description
_The commit messages say what you did; this should explain why and how._
- Fixed some typos
- Image height/width are now scaled down to match fallback-image size (1280×???)
