### PR TITLE
Add quickstart oddbirding guide

### DIFF
--- a/content/jobs/index.md
+++ b/content/jobs/index.md
@@ -7,9 +7,9 @@ eleventyComputed:
   title: Jobs
 ---
 
-Learn more about our team structure,
+Learn more about our team structure --
 what we're offering,
-and what we expect from you,
+and what we expect from you --
 in our full
 [OddBirding Guide](/quickstart/).
 

--- a/content/jobs/index.md
+++ b/content/jobs/index.md
@@ -7,6 +7,12 @@ eleventyComputed:
   title: Jobs
 ---
 
+Learn more about our team structure,
+what we're offering,
+and what we expect from you,
+in our full
+[OddBirding Guide](/quickstart/).
+
 {% import 'utility.macros.njk' as utility %}
 {% set jobs = collections.all | withData('data.position', 'open') %}
 

--- a/content/jobs/jobs.11tydata.yaml
+++ b/content/jobs/jobs.11tydata.yaml
@@ -61,6 +61,12 @@ eleventyComputed:
     are set collaboratively as a team,
     and change over time.
 
+    Learn more about our team structure --
+    what we're offering,
+    and what we expect from you --
+    in our full
+    [OddBirding Guide](/quickstart/).
+
     ## Interested?
 
     Let's talk!

--- a/content/quickstart.md
+++ b/content/quickstart.md
@@ -4,17 +4,17 @@ sub: Welcome to OddBird!
 image:
   svg: faces/oddbird
   alt: |
-    Illustrated faces: 
+    Illustrated faces:
     Carl, Kit, Stacy, Miriam, Sondra, Erica, and Jonny
-summary: | 
+summary: |
   OddBird was founded in 2008 by three siblings --
-  [Miriam](/authors/miriam/), 
-  [Jonny](/authors/jonny/), and 
+  [Miriam](/authors/miriam/),
+  [Jonny](/authors/jonny/), and
   [Carl](/authors/carl/).
-  Since then we've grown to be 
+  Since then we've grown to be
   a small team of web contractors
-  collaborating on custom web sites, 
-  applications, and tools. 
+  collaborating on custom web sites,
+  applications, and tools.
   This is your guide to working with our team:
   *what we’re offering,
   and what we expect in return*.
@@ -41,7 +41,7 @@ summary: |
 
 We want your time with OddBird to be fun,
 challenging, educational, and rewarding.
-One of the owners will schedule 
+One of the owners will schedule
 a regular check-in with you
 to see how things are going,
 and help along the way.
@@ -68,7 +68,7 @@ and the owners will give a financial report
 at the beginning of every month.
 We will also maintain a yearly spreadsheet
 showing the company finances, income, and expenses —
-including the hours worked,
+including the hours worked
 and pay invoiced by each contractor.
 
 ### Consistency
@@ -182,7 +182,7 @@ of all our contributors.
 We take harassment seriously,
 and want to look out for your well-being.
 
-[coc]: http://oddbird.net/conduct
+[coc]: /conduct
 
 ### Yearly Bonus
 

--- a/content/quickstart.md
+++ b/content/quickstart.md
@@ -1,0 +1,338 @@
+---
+title: OddBirding Guide
+sub: Welcome to OddBird!
+image:
+  svg: faces/oddbird
+  alt: |
+    Illustrated faces: 
+    Carl, Kit, Stacy, Miriam, Sondra, Erica, and Jonny
+summary: | 
+  OddBird was founded in 2008 by three siblings --
+  [Miriam](/authors/miriam/), 
+  [Jonny](/authors/jonny/), and 
+  [Carl](/authors/carl/).
+  Since then we've grown to be 
+  a small team of web contractors
+  collaborating on custom web sites, 
+  applications, and tools. 
+  This is your guide to working with our team:
+  *what we’re offering,
+  and what we expect in return*.
+---
+
+## Moving Thoughtfully:
+
+- We strive to help our clients and users
+  solve complex problems with technology
+  that respects their agency, expertise, and diversity.
+- We strive to build a diverse team of experts
+  creating sustainable careers together --
+  with meaningful work, steady income,
+  flexible schedules, and shared profits.
+- We strive to keep the company at a size where
+  everyone knows each other,
+  and there is enough overlap to take vacations
+- We strive to choose internal & client projects
+  that have a positive impact on the world.
+- We strive to be teachers in the industry,
+  actively participating in the open-web.
+
+## Our Commitment to You:
+
+We want your time with OddBird to be fun,
+challenging, educational, and rewarding.
+One of the owners will schedule 
+a regular check-in with you
+to see how things are going,
+and help along the way.
+
+### Equal Compensation
+
+- All senior-level contractors
+  are paid equally for client work
+  (currently \$100/hr – open to change as the team deems necessary)
+  across all skillsets.
+  Some internal work is paid at lower rates,
+  when agreed on by the team.
+- If we bring on a junior-level contractor
+  they may be temporarily paid $60-$80/hr,
+  with a clear path to graduate
+  into a senior position.
+- Intern compensation
+  is determined on a case-by-case basis.
+
+### Transparency
+
+Our books are open to the team,
+and the owners will give a financial report
+at the beginning of every month.
+We will also maintain a yearly spreadsheet
+showing the company finances, income, and expenses —
+including the hours worked,
+and pay invoiced by each contractor.
+
+### Consistency
+
+OddBird maintains a “rainy-day” fund
+to smooth over the impact
+of fluctuations in available client work,
+and we aim to keep this fund
+at a level sufficient to keep the team working
+on internal projects for up to three months
+without client work.
+
+### Education & Technology
+
+OddBird provides \$1000 a year
+towards continuing education related to your work —
+conferences, classes, books, etc.
+
+OddBird also provides \$500 each year
+towards technology purchases
+that contribute to your daily work.
+If unused in a year, this money rolls over
+to subsequent years.
+
+These benefits are available
+after you’ve been working with OddBird
+for at least six months.
+
+### Flexibility
+
+All work is remote,
+and all pay is hourly.
+You are never required to work more hours
+than you are interested and able.
+Take a vacation whenever you need,
+take the afternoon off to play with your kids,
+or work a bit extra to buy yourself a treat.
+Just let the team know your schedule in advance,
+so we can all adjust as needed.
+
+### Adaptability
+
+If you are interested in learning
+aspects of the process that are new and interesting to you
+(a designer interested in Python?),
+let us know, and we’ll help you get there.
+We’re open to adjusting job descriptions,
+and even facilitating horizontal movement in the company.
+
+### Participation
+
+We’re a small company,
+and everyone has a say in the direction we want to go.
+While owners will have final say in major company decisions,
+we want the entire team involved in the conversation.
+
+- We have bi-weekly video check-ins
+  with the full team
+  to discuss what’s working,
+  and what might need to change.
+- We have “all hands” work retreats
+  twice a year,
+  for more intensive in-person planning and playing.
+  OddBird covers all the costs
+  of travel, lodging, and food when we get together —
+  and pays a daily rate
+  (currently \$400/day)
+  during the retreat.
+- We pay for internal OddBird work required to grow the company,
+  or improve our processes.
+  If you have ideas you’d like to help implement,
+  bring a proposal to the team,
+  with an estimated budget for the project.
+  We’ll try to make it happen!
+
+### Giving Back
+
+Every month,
+up to 10% of your invoice to OddBird
+can be time spent on open-source contributions,
+work-related blogging or book-writing,
+and conference talks.
+We also contribute regularly to charities
+that help improve diversity-in-tech,
+and we’re open to your suggestions
+on where our money should go.
+
+### Communication
+
+One of the owners will be assigned
+to check in with you on a regular basis,
+and be available as-needed
+for any questions or concerns you might have.
+We want to know how things are going for you!
+
+If there are concerns
+with your work performance or team interaction,
+we will talk with you about them
+and give you a chance to correct the problem,
+before making a decision
+to remove you from the team.
+In case of serious misconduct,
+you may be removed from the team immediately.
+
+### Safety
+
+OddBird has a comprehensive
+[Code of Conduct][coc]
+to ensure the comfort and safety
+of all our contributors.
+We take harassment seriously,
+and want to look out for your well-being.
+
+[coc]: http://oddbird.net/conduct
+
+### Yearly Bonus
+
+End-of-year bonuses
+depend on how the company is doing
+in a given year.
+
+## Your Commitment to OddBird:
+
+### Communication
+
+OddBird puts a high value on flexibility.
+We want the company to fit your life,
+not the other way around.
+Good communication is required
+to make that possible,
+but most everything else
+is flexible with prior arrangement.
+Let us know what you are thinking,
+and what you need,
+and we’ll work with you to make it possible.
+
+- Let us know when you will be out of the office
+  or unavailable,
+  so we can plan accordingly.
+  We encourage you to take time away from work,
+  and turn off notifications while you are out —
+  but we also need to plan around your absence.
+- Respond to questions in [Slack][slack] and [Trello][trello]
+  in a timely fashion.
+  Questions may be asked at any time of day or night or weekend
+  (so turn off notifications if you don’t want to be disturbed),
+  but we only expect participation during our normal working hours
+  (see [Scheduling](#scheduling) below).
+- Follow the [Code of Conduct][coc] at all times,
+  to ensure the safety of all our contributors.
+- If you aren’t sure, ask!
+  Always err on the side of communicating more.
+
+[slack]: http://oddbird.slack.com/
+[trello]: https://trello.com/
+
+### Scheduling
+
+While you determine your own work schedule,
+we have some basic requests
+for availability and overlap with the team.
+Here are a few assumptions we’ll make,
+unless you arrange something different with us in advance:
+
+- Join our daily “stand-up” video-chat,
+  weekdays at 11:30am Eastern Time unless otherwise noted.
+- Be available regularly
+  in our Slack channels
+  between ~11:30am and ~5:00pm Eastern Time on weekdays.
+  Even if you are not actively working at the time,
+  it’s good to be available for questions
+  from other OddBird contributors during these hours.
+- Attend the “all-hands” work retreats
+  (currently twice a year).
+  We understand that not everyone has the same flexibility for travel,
+  so we’ll go out of our way to make retreats
+  as convenient as possible for everyone involved.
+  Let us know if you have any concerns.
+
+If you plan to be unavailable or not working
+for a full day or more,
+please add your plans as an event on the
+OddBird Availability [Google Calendar][gcal].
+
+[gcal]: https://calendar.google.com/
+
+### Participation
+
+We like to work collaboratively on each feature,
+passing responsibility back and forth
+so that everyone on the team
+has an understanding of the user-story goals,
+requirements, and implementation.
+It requires active communication
+and consistent documentation
+to keep everyone up-to-speed.
+
+- All of our work is reviewed
+  by another member of the team —
+  including UX proposals, designs, code, and copy.
+  UX proposals and designs are reviewed before implementation,
+  and code is reviewed before it is merged into the main branch.
+  Seek out reviews of your work from others on the team,
+  be ready to review others’ work,
+  and expect to make changes based on a review.
+  It’s worth the time to make improvements when we find them.
+- Be gracious on either end of a code review.
+  We are all working together to improve the quality of our work.
+  Discuss the code, not the developer,
+  giving feedback honestly and politely.
+  Accept critique with an open mind,
+  but feel free to push back,
+  and provide context for your decisions.
+  There is never only one valid solution,
+  but a conversation often helps strengthen the final product.
+- We rely heavily on [Trello][trello]
+  for managing our process across a remote team.
+  You can look in Trello
+  to find what user stories are available or assigned to you,
+  what the priorities are,
+  and what others are working on.
+  Keep Trello up-to-date as you work,
+  so that others can see the status of a story,
+  and any relevant conversations and decisions
+  that have been made about its implementation.
+
+### Finding Clients
+
+As a small consulting company,
+OddBird relies on each of our contributors
+to be involved in bringing in new work.
+If you are at a conference,
+a local tech meetup,
+or anywhere else,
+we hope that you’ll mention OddBird
+(where appropriate)
+when introducing yourself,
+and keep your eyes and ears open
+for clients who could use our services.
+
+### Billing
+
+OddBird pays invoices on a monthly basis,
+and sends invoices to clients on the same schedule.
+
+- Track your billable hours
+  consistently and accurately
+  in the company-provided software
+  (currently [Harvest][harvest]).
+  Time is “billable”
+  when it is spent actively working
+  on a client project,
+  approved OddBird-internal projects,
+  meetings/stand-ups/check-ins,
+  or your 10% “giving back” time.
+- Submit an hourly invoice,
+  itemized by client/project,
+  with each line-item rounded up to the nearest half-hour,
+  to [accounts@oddbird.net][accounts]
+  on the first business day of every month.
+  Timely invoices help us bill clients more efficiently.
+  If you can’t get your invoice in,
+  let the owners know,
+  and we can pull your hours from the shared time tracker.
+
+[harvest]: https://www.getharvest.com/
+[accounts]: mailto:accounts@oddbird.net


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of [animals](https://unsplash.com/t/animals)._

![](https://images.unsplash.com/photo-1601908668930-e1269720ec20?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=900&q=60)

## Description
_The commit messages say what you did; this should explain why and/or how._

- Adds the quickstart guide to oddsite
- linked from the `jobs` index, and each individual job description
