### PR TITLE
Fix layout overlap of nav and logo

### DIFF
--- a/src/scss/layout/_banner.scss
+++ b/src/scss/layout/_banner.scss
@@ -22,10 +22,12 @@
   &:link,
   &:visited {
     @include tools.transition('move');
+    @include tools.z-index('bump');
     align-self: start;
     display: block;
     grid-area: logo;
     margin-top: var(--half-shim);
+    position: relative;
     transform-origin: top center;
   }
 


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of [animals](https://unsplash.com/t/animals)._

![](https://images.unsplash.com/photo-1603476246648-5a2a8e5089c5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=900&q=60)

## Link to Trello card (if applicable)
_If this PR relates to a Trello card, don't forget to reference this PR on the card as well._

https://trello.com/c/Oo4Uvx9g/112-nav-covers-up-bottom-half-of-oddbird-logo

## Description
_The commit messages say what you did; this should explain why and/or how._
- [x] Description is in Trello card



## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

Try to hover the bottom half of the logo
