### PR TITLE
fix title overflow on container query post

### DIFF
--- a/content/blog/2021/containerqueries.md
+++ b/content/blog/2021/containerqueries.md
@@ -1,6 +1,6 @@
 ---
 card: large
-title: Getting Started with Container Queries
+title: "Container Queries: a Quick Start Guide"
 sub: Now is the time to begin experimenting with a long requested layout tool.
 author: davidh
 date: 2021-04-05


### PR DESCRIPTION
## Cute animal pic
![image](https://user-images.githubusercontent.com/41588129/113697453-7d563680-96d3-11eb-8417-8b4c664905e4.png)

_Because everyone likes pictures of [animals](https://unsplash.com/t/animals)._



## Link to Trello card (if applicable)
_If this PR relates to a Trello card, don't forget to reference this PR on the card as well._



## Description
The two relatively longish words "container queries" sitting next to each other in the title was causing overflow on narrow screens. I reworked the title a bit so that words wrap differently. 
_The commit messages say what you did; this should explain why and/or how._
- [ ] Description is in Trello card



## Steps to test/reproduce
View the container query article on the resources page. 
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._



## Show me
Old:
![image](https://user-images.githubusercontent.com/41588129/113698015-4d5b6300-96d4-11eb-83da-2c41faf84cd0.png)


New:
![image](https://user-images.githubusercontent.com/41588129/113697920-2b61e080-96d4-11eb-9715-f6c39c327432.png)

_Provide screenshots/animated gifs/videos if necessary._
