### PR TITLE
Update twitter/codepen usernames and remove unconfirmed talks

### DIFF
--- a/content/_includes/embed.macros.njk
+++ b/content/_includes/embed.macros.njk
@@ -552,7 +552,7 @@ params:
     note: Used in the default fallback link
   user:
     type: string
-    note: The CodePen username, eg 'mirisuzanne'
+    note: The CodePen username, eg 'miriamsuzanne'
   tab:
     type: string
     default: 'result'

--- a/content/birds/miriam.md
+++ b/content/birds/miriam.md
@@ -8,9 +8,9 @@ image:
   width: 2160
   height: 743
 social:
-  twitter: mirisuzanne
-  github: mirisuzanne
-  codepen: mirisuzanne
+  twitter: TerribleMia
+  github: MiriSuzanne
+  codepen: MiriamSuzanne
   stackoverflow: 1930386
 summary: |
   Miriam is a co-founder and front-end architect --

--- a/content/blog/2012/susy-off-canvas.md
+++ b/content/blog/2012/susy-off-canvas.md
@@ -34,7 +34,7 @@ layout. All you need to do is pull some of your columns off the screen.
 I'll show you how, following Jason's lead, and adding in the Susy bits.
 
 Check out the
-[demo](https://codepen.io/mirisuzanne/pen/c84837d2f8c478b6a3accca409c790eb), and
+[demo](https://codepen.io/miriamsuzanne/pen/c84837d2f8c478b6a3accca409c790eb), and
 make sure you understand off-canvas layouts before you go on.
 
 I've used a few shortcuts that require the [latest Susy
@@ -231,14 +231,14 @@ have leftover classes, and you're done.
 {{ embed.codepen(
   id='c84837d2f8c478b6a3accca409c790eb',
   title='Susy1 Off-Canvas Demo',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 ## Final Tweaks
 
 I've added a number of styles to make it obvious what's going on and
 highlight the transitions in our
-[demo](https://codepen.io/mirisuzanne/pen/c84837d2f8c478b6a3accca409c790eb).
+[demo](https://codepen.io/miriamsuzanne/pen/c84837d2f8c478b6a3accca409c790eb).
 You also need a bit of JS to make the toggles work, but this is all you
 need for the Susy setup.
 

--- a/content/blog/2013/isolation-susy.md
+++ b/content/blog/2013/isolation-susy.md
@@ -50,7 +50,7 @@ with the simple `isolate()` mixin:
 {{ embed.codepen(
   id='ad41121d402b5faccd1dbee4e88e35d1',
   title='Susy Isolation Demo: Syntax',
-  user='mirisuzanne',
+  user='miriamsuzanne',
   height=300
 ) }}
 
@@ -60,7 +60,7 @@ removed from the flow:
 {{ embed.codepen(
   id='93faa807c78fb4e9b1e15af2727d22d1',
   title='Susy Isolation Demo: Multiple',
-  user='mirisuzanne',
+  user='miriamsuzanne',
   height=300
 ) }}
 
@@ -85,7 +85,7 @@ Change the span-width, and we'll update everything for you:
 {{ embed.codepen(
   id='c891305b8d32d1306fc305846cfd926f',
   title='Susy Isolation Demo: Gallery',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 ## Bleed
@@ -100,7 +100,7 @@ Here's an element bleeding 1-column outside our 6-column page layout:
 {{ embed.codepen(
   id='351a144615300d48574188af838764ea',
   title='Susy1 Bleed Demo: Syntax',
-  user='mirisuzanne',
+  user='miriamsuzanne',
   height=300
 ) }}
 
@@ -114,7 +114,7 @@ pass arbitrary widths in the first argument:
 {{ embed.codepen(
   id='c8eb354821f8441e8c4b28864f92a8dd',
   title='Susy1 Bleed Demo: Sides',
-  user='mirisuzanne',
+  user='miriamsuzanne',
   height=300
 ) }}
 

--- a/content/blog/2017/css-day.md
+++ b/content/blog/2017/css-day.md
@@ -59,7 +59,7 @@ leading to her recent [SVG Animations] book from O'Reilly.
 
 - [Slides](https://oddbooksapp.com/book/pattern-making)
 
-[Miriam Suzanne]: https://twitter.com/mirisuzanne/
+[Miriam Suzanne]: https://twitter.com/TerribleMia/
 
 ## The In-Betweeners of Responsive Web Design by [Pralie Dutzel]
 

--- a/content/blog/2017/pattern-making.md
+++ b/content/blog/2017/pattern-making.md
@@ -283,7 +283,7 @@ color (`#339` above), and then call the adjustment function mentioned
 
 You can play with it yourself in this CodePen demo:
 
-<p data-height="420" data-theme-id="0" data-slug-hash="xqOwxe" data-default-tab="css,result" data-user="mirisuzanne" data-embed-version="2" data-pen-title="Accoutrement Color Example" data-editable="true" class="codepen">See the Pen <a href="https://codepen.io/mirisuzanne/pen/xqOwxe/">Accoutrement Color Example</a> by Miriam Suzanne (<a href="https://codepen.io/mirisuzanne">@mirisuzanne</a>) on <a href="https://codepen.io">CodePen</a>.</p>
+<p data-height="420" data-theme-id="0" data-slug-hash="xqOwxe" data-default-tab="css,result" data-user="miriamsuzanne" data-embed-version="2" data-pen-title="Accoutrement Color Example" data-editable="true" class="codepen">See the Pen <a href="https://codepen.io/miriamsuzanne/pen/xqOwxe/">Accoutrement Color Example</a> by Miriam Suzanne (<a href="https://codepen.io/miriamsuzanne">@miriamsuzanne</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
 
 As you can see, that demo also generates a rough style guide on-the-fly,

--- a/content/blog/2017/susy-use.md
+++ b/content/blog/2017/susy-use.md
@@ -51,7 +51,7 @@ action:
 {{ embed.codepen(
   id='NadbNR',
   title='CSS Variable Breakpoints',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 ## Sass Limitations

--- a/content/blog/2017/susy3.md
+++ b/content/blog/2017/susy3.md
@@ -111,7 +111,7 @@ code:
 {{ embed.codepen(
   id='0229f885f9a574c6d049b9d30dffc609',
   title='CSS Grid Demo',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 In most cases, you can also provide a float, flexbox, or css-table
@@ -247,7 +247,7 @@ of CSS [custom properties] (aka variables):
 {{ embed.codepen(
   id='d05d2ea9339419df7070f9c393a9c080',
   title='Calc() + Custom Properties',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 That will also work with css-tables, etc. Add any padding you like, and
@@ -259,7 +259,7 @@ experiment, but I don't recommend using it in production:
 {{ embed.codepen(
   id='PboVrw',
   title='SusyCSS Demo',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 Susy is designed to handle any layout, but if you are designing grids in
@@ -282,7 +282,7 @@ Here's an example flexbox layout, without Susy:
 {{ embed.codepen(
   id='657a71f05b9c044d0235bab212abdbdc',
   title='Full-height Flexbox',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 If you do want to use Susy with flexbox to achieve more consistent
@@ -320,7 +320,7 @@ do that work for you, but it can be a powerful fallback:
 {{ embed.codepen(
   id='70b5a2cf411542e74d1cd42d5ddbe446',
   title='Floats with Calc',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 ## Introducing Susy3

--- a/content/blog/2018/beyondtellerand.md
+++ b/content/blog/2018/beyondtellerand.md
@@ -67,7 +67,7 @@ Asteroids-inspired browser snippet so you can destroy your creation.
 Enjoy the invasion!
 
 <figure class="extend-large">
-  <p data-height="600" data-theme-id="0" data-slug-hash="LmrEmb" data-default-tab="result" data-user="mirisuzanne" data-embed-version="2" data-pen-title="Vue Invaders!" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/mirisuzanne/pen/LmrEmb/">Vue Invaders!</a> by Miriam Suzanne (<a href="https://codepen.io/mirisuzanne">@mirisuzanne</a>) on <a href="https://codepen.io">CodePen</a>.</p>
+  <p data-height="600" data-theme-id="0" data-slug-hash="LmrEmb" data-default-tab="result" data-user="miriamsuzanne" data-embed-version="2" data-pen-title="Vue Invaders!" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/miriamsuzanne/pen/LmrEmb/">Vue Invaders!</a> by Miriam Suzanne (<a href="https://codepen.io/miriamsuzanne">@miriamsuzanne</a>) on <a href="https://codepen.io">CodePen</a>.</p>
   <script async src="https://static.codepen.io/assets/embed/ei.js"></script>
 </figure>
 
@@ -89,7 +89,7 @@ favorites:
 
 [Levitated Toy Factory]: http://levitated.guru/
 [one of his art pieces]: http://levitated.net/daily/levInvaderFractal.html
-[second draft]: https://codepen.io/mirisuzanne/pen/gzXqOP
+[second draft]: https://codepen.io/miriamsuzanne/pen/gzXqOP
 [Vue]: https://vuejs.org/
 [A Tinker Story]: https://beyondtellerrand.com/events/dusseldorf-2018/speakers/dina-amin#talk
 [Broad Band]: https://beyondtellerrand.com/events/dusseldorf-2018/speakers/claire-evans#talk

--- a/content/blog/css-tricks/css-art.md
+++ b/content/blog/css-tricks/css-art.md
@@ -88,7 +88,7 @@ with a few custom properties to make adjustment easier:
 {{ embed.codepen(
   id='eYdJvWE',
   title='CSS gradient-art decorations',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}
 
 Last week we used a similar trick

--- a/content/blog/css-tricks/stacks.md
+++ b/content/blog/css-tricks/stacks.md
@@ -26,5 +26,5 @@ summary: |
 {{ embed.codepen(
   id='GRpmOjr',
   title='Custom Property Cascades (sass function)',
-  user='mirisuzanne'
+  user='miriamsuzanne'
 ) }}

--- a/content/blog/mozdev/list-marker.md
+++ b/content/blog/mozdev/list-marker.md
@@ -23,7 +23,7 @@ I'll also show you how the `::marker` element
 is different from `::before` or `::after`.
 Watch the video, and go play with the [demo on codepen][pen].
 
-[pen]: https://codepen.io/mirisuzanne/pen/BaBKowO?editors=0100
+[pen]: https://codepen.io/miriamsuzanne/pen/BaBKowO?editors=0100
 
 {{ embed.figure(
   data=media,

--- a/content/blog/mozdev/mozdev.md
+++ b/content/blog/mozdev/mozdev.md
@@ -82,4 +82,4 @@ articles, demos, and some exciting new open source tools.
 
 [channel]: https://www.youtube.com/MozillaDeveloper
 [dark mode demo]: https://empathic-dev.github.io/HelloDarkness/
-[demo on CodePen]: https://codepen.io/mirisuzanne/pen/BaBKowO?editors=0100
+[demo on CodePen]: https://codepen.io/miriamsuzanne/pen/BaBKowO?editors=0100

--- a/content/blog/mozdev/overflow-wrap.md
+++ b/content/blog/mozdev/overflow-wrap.md
@@ -34,4 +34,4 @@ and how to use them.
 
 - [MDN Overflow-Wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
 - [MDN Hyphens](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens)
-- [CodePen Demo](https://codepen.io/mirisuzanne/pen/GRKoxXY)
+- [CodePen Demo](https://codepen.io/miriamsuzanne/pen/GRKoxXY)

--- a/content/blog/mozdev/revert.md
+++ b/content/blog/mozdev/revert.md
@@ -34,4 +34,4 @@ It rolls back styles to the expected browser default for each element,
 rather than using the specification default for each property.
 
 - MDN [documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/revert)
-- CodePen [demo](https://codepen.io/mirisuzanne/pen/WVjNZP)
+- CodePen [demo](https://codepen.io/miriamsuzanne/pen/WVjNZP)

--- a/content/blog/mozdev/scroll-snap.md
+++ b/content/blog/mozdev/scroll-snap.md
@@ -28,6 +28,6 @@ media:
   caption="The fallback even works well in old browsers!"
 ) }}
 
-- [Image Gallery Demo](https://codepen.io/mirisuzanne/pen/bXRebo?editors=0100)
-- [Page Sections Demo](https://codepen.io/mirisuzanne/pen/vomNBg?editors=0100)
+- [Image Gallery Demo](https://codepen.io/miriamsuzanne/pen/bXRebo?editors=0100)
+- [Page Sections Demo](https://codepen.io/miriamsuzanne/pen/vomNBg?editors=0100)
 - [More on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap/Basic_concepts)

--- a/content/open-source/csswg.md
+++ b/content/open-source/csswg.md
@@ -30,5 +30,5 @@ to structured documents and Web applications.
 By separating the presentation style from the content,
 CSS simplifies Web authoring and site maintenance.
 
-All my research, explainers, and proposals 
-are available at [css.oddbird.net](https://css.oddbird.net/)
+All my research, explainers, and proposals
+are available at [css.oddbird.net](https://css.oddbird.net/).

--- a/content/open-source/csswg.md
+++ b/content/open-source/csswg.md
@@ -29,3 +29,6 @@ allowing authors and users to attach style
 to structured documents and Web applications.
 By separating the presentation style from the content,
 CSS simplifies Web authoring and site maintenance.
+
+All my research, explainers, and proposals 
+are available at [css.oddbird.net](https://css.oddbird.net/)

--- a/content/talks/agile-systems.md
+++ b/content/talks/agile-systems.md
@@ -48,7 +48,7 @@ events:
     date: 2018-03-21
 press:
   - text: |
-      Every time I hear @mirisuzanne
+      Every time I hear @TerribleMia
       talk I learn a ton and laugh a ton.
       She’s an amazing speaker...
       Watch this talk when it’s published!

--- a/content/talks/dynamic-css.md
+++ b/content/talks/dynamic-css.md
@@ -15,11 +15,11 @@ tags:
   - Vue
   - Layout
 events:
-  - venue: Webconf.asia
-    url: https://webconf.asia/
-    date: 2021-06-04
-    end: 2021-06-05
-    adr: Hong Kong
+  # - venue: Webconf.asia
+  #   url: https://webconf.asia/
+  #   date: 2021-06-04
+  #   end: 2021-06-05
+  #   adr: Hong Kong
   - venue: Shift Remote
     url: https://remote.shiftconf.co/
     date: 2020-08-06
@@ -90,7 +90,7 @@ events:
 press:
   - text: |
       Some pretty mind-bendingly cool uses for CSS custom props
-      from @MiriSuzanne --
+      from @TerribleMia --
       color, layout & animation all in css
       and only using JS to feed data.
     slug: mind-bending
@@ -100,7 +100,7 @@ press:
     face: jason-pamental.jpg
     url: https://twitter.com/jpamental/status/1118585546803036160
   - text: |
-      Best CSS talk I've ever seen was from @MiriSuzanne
+      Best CSS talk I've ever seen was from @TerribleMia
       today at #dvlpdnvr. Simply amazing.
     name: Michael Dowden
     title: Co-Author
@@ -111,7 +111,7 @@ press:
       Well that was awesome!!!
       “If you think CSS is a dumb language,
       you’re a dumb language – CSS IS AWESOME!”
-      @MiriSuzanne thank you so much for the amazing talk!
+      @TerribleMia thank you so much for the amazing talk!
     name: Nour Saud
     title: Software Engineer
     face: nour-saud.jpg

--- a/content/talks/responsive-components.md
+++ b/content/talks/responsive-components.md
@@ -20,11 +20,11 @@ events:
     date: 2021-04-23
     end: 2021-04-30
     adr: Online
-  - venue: Modern Web Conference
-    url: https://modernwebconference.com/
-    date: 2021-05-17
-    end: 2021-05-28
-    adr: Online
+  # - venue: Modern Web Conference
+  #   url: https://modernwebconference.com/
+  #   date: 2021-05-17
+  #   end: 2021-05-28
+  #   adr: Online
 summary: |
   New CSS proposals like Container Queries,
   Cascade Layers, Scoped Styles, and Nesting

--- a/content/work/mozdev.md
+++ b/content/work/mozdev.md
@@ -11,7 +11,7 @@ links:
 index: Mozilla Developer Channel
 press:
   - text: |
-      Are you following @MiriSuzanne yet? She's amazing.
+      Are you following @TerribleMia yet? She's amazing.
       **I'm so lucky to get to work with her on this video series & more.**
     name: Jen Simmons
     title: Designer & Developer Advocate
@@ -19,7 +19,7 @@ press:
     url: https://twitter.com/jensimmons/status/1182658268457512961
     slug: amazing
   - text: |
-      @MiriSuzanne does not only explain “why CSS is how it is”
+      @TerribleMia does not only explain “why CSS is how it is”
       but also neatly **summarizes the basic principles
       of what make the Web the Web.**
       If you know those principles,


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of [animals](https://unsplash.com/t/animals)._

![lizzard](https://images.unsplash.com/photo-1619577110193-99c07e83f4b3?ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDE4fEpwZzZLaWRsLUhrfHxlbnwwfHx8fA%3D%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=900&q=60)

## Description
_The commit messages say what you did; this should explain why and/or how._

- I didn't like having all my usernames based on `miri`, when that's not a name I actually use. So I changed my username on sites that would be the most likely to redirect properly.
- I also commented out two talks that are likely being re-scheduled or cancelled. No reason to advertise false dates.
