### PR TITLE
Add GH Actions for shadow repo

### DIFF
--- a/.github/workflows/shadow-branch.yml
+++ b/.github/workflows/shadow-branch.yml
@@ -1,0 +1,19 @@
+name: shadow-branch
+
+on: create
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    env:
+      API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      SHADOW_OWNER: ${{ secrets.SHADOW_OWNER }}
+      SHADOW_REPO: ${{ secrets.SHADOW_REPO }}
+    steps:
+      - name: Get branch name
+        run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Create branch on shadow repo
+        run: |
+          git clone --single-branch "https://$API_TOKEN_GITHUB@github.com/$SHADOW_OWNER/$SHADOW_REPO.git" REPOTMP
+          cd REPOTMP
+          git push origin "main:$BRANCH_NAME"

--- a/.github/workflows/shadow-push.yml
+++ b/.github/workflows/shadow-push.yml
@@ -1,0 +1,29 @@
+name: shadow-push
+
+on: push
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    env:
+      API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env vars
+        run: |
+          echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo NODE_VERSION=`cat .nvmrc` >> $GITHUB_ENV
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn build
+      - name: Push to shadow branch
+        uses: cpina/github-action-push-to-another-repository@2ebe0cc15fc6a8e63c3658c119525bf1aead4418
+        with:
+          source-directory: _site
+          destination-github-username: ${{ secrets.SHADOW_OWNER }}
+          destination-repository-name: ${{ secrets.SHADOW_REPO }}
+          user-email: ${{ secrets.SHADOW_AUTHOR }}
+          target-branch: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&2109091)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description
This configures GitHub Actions to build the site and push the `_site` folder to https://github.com/oddbird/oddleventy-built/. It will shadow the branch structure so diffing between `main` and any PR branch should show exactly what is changing in the final HTML.

_Keep in mind the `main` branch on `oddlevent-built` is currently empty so not really useful. Once this PR is merged `main` will receive all the contents of the `_site` folder. You can preview them in https://github.com/oddbird/oddleventy-built/tree/push-to-shadow_

## Steps to test/reproduce
No need to do anything locally. GH Actions will keep building and committing to the shadow repo on all pushes to all branches.