### PR TITLE
sort work sample list by end date

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -79,12 +79,19 @@ module.exports = (eleventyConfig) => {
     collection
       .getAll()
       .filter((item) => item.data.client)
-
-      // @@@ to-do
-      // sort in descending order by end date
-      // if no end date, sort in descending order by date
-
-      .sort((a, b) => b.data.end - a.data.end),
+      .sort((a, b) => {
+        if (!a.data.end) {
+          if (a.date > b.data.end) {
+            return -1;
+          }
+        }
+        if (!b.data.end) {
+          if (a.data.end > b.date) {
+            return -1;
+          }
+        }
+        return b.data.end - a.data.end;
+      }),
   );
   eleventyConfig.addCollection('sample', (collection) =>
     collection.getAll().filter((item) => item.data.sample),

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -81,14 +81,10 @@ module.exports = (eleventyConfig) => {
       .filter((item) => item.data.client)
       .sort((a, b) => {
         if (!a.data.end) {
-          if (a.date > b.data.end) {
-            return -1;
-          }
+          return b.data.end ? -1 : b.date - a.date;
         }
         if (!b.data.end) {
-          if (a.data.end > b.date) {
-            return -1;
-          }
+          return 1;
         }
         return b.data.end - a.data.end;
       }),

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -79,7 +79,12 @@ module.exports = (eleventyConfig) => {
     collection
       .getAll()
       .filter((item) => item.data.client)
-      .sort((a, b) => b.date - a.date),
+
+      // @@@ to-do
+      // sort in descending order by end date
+      // if no end date, sort in descending order by date
+
+      .sort((a, b) => b.data.end - a.data.end),
   );
   eleventyConfig.addCollection('sample', (collection) =>
     collection.getAll().filter((item) => item.data.sample),

--- a/content/_includes/page/meta.njk
+++ b/content/_includes/page/meta.njk
@@ -30,7 +30,7 @@
         {{ post.pubdate(
           start=page.date,
           end=end,
-          format='range' if oss else 'long'
+          format='range' if oss or client else 'long'
         ) }}
         {{ post.where(adr) }}
       </p>

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -180,7 +180,7 @@ params:
           post=post,
           collections=collections,
           links=false,
-          dateformat='month_day'
+          dateformat='range' if post.data.client else 'month_day'
         ) }}
       </header>
       {% if post.data.events %}

--- a/content/work/carrotproject.md
+++ b/content/work/carrotproject.md
@@ -8,7 +8,8 @@ client: &client The Carrot Project
 people:
   - name: Jake de Grazia
     venue: *client
-date: 2010-03-15
+date: 2008-09-30
+end: 2010-03-28
 tasks:
   - Product Branding
   - User Experience Design

--- a/content/work/coachhub.md
+++ b/content/work/coachhub.md
@@ -16,8 +16,8 @@ people:
     url: https://www.linkedin.com/in/sarataillon/
     title: CTO
     venue: *client
-date: 2014-01-01
-end: 2016-01-01
+date: 2014-04-24
+end: 2016-08-31
 links:
   site: https://coachhub.resilienceboost.com/
 tags:

--- a/content/work/craftisan.md
+++ b/content/work/craftisan.md
@@ -2,7 +2,8 @@
 eleventyExcludeFromCollections: true
 title: Craftisan
 client: Craftisan
-date: 2011-04-15
+date: 2010-07-31
+end: 2011-06-01
 tasks:
   - Product Branding
   - User Experience

--- a/content/work/emmysworkshop.md
+++ b/content/work/emmysworkshop.md
@@ -6,7 +6,8 @@ image:
 client: &client Carleton College
 links:
   site: https://turing.mathcs.carleton.edu/production/AlgebraSolving.html
-date: 2017-01-15
+date: 2016-08-01
+end: 2018-06-30
 tasks:
   - Branding
   - Responsive front-end architecture

--- a/content/work/expression-builder.md
+++ b/content/work/expression-builder.md
@@ -3,8 +3,8 @@ title: Expression Builder
 sub: Tools for data analytics
 logo: aunalytics
 client: &client Aunalytics
-date: 2018-05-14
-end: 2019-05-14
+date: 2018-11-19
+end: 2019-05-31
 image:
   src: work/expression-builder/exbldr.jpg
   alt: Tools for data analytics

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -34,8 +34,8 @@ summary: |
             {% set years = utility.datetime(
               start=item.date,
               end=item.data.end,
-              format='year',
-              prefix=none
+              format='range' if not item.data.end else 'year',
+              prefix=true if not item.data.end else none
             ) %}
             {{ post.subtitle(
               [years, item.data.sub] | join(' -- ')

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -34,8 +34,8 @@ summary: |
             {% set years = utility.datetime(
               start=item.date,
               end=item.data.end,
-              format='range' if not item.data.end else 'year',
-              prefix=true if not item.data.end else none
+              format='year' if item.data.end else 'range',
+              prefix=none if item.data.end else true
             ) %}
             {{ post.subtitle(
               [years, item.data.sub] | join(' -- ')

--- a/content/work/masterlookup.md
+++ b/content/work/masterlookup.md
@@ -3,7 +3,8 @@ eleventyExcludeFromCollections: true
 title: Master Lookup Table
 sub: Parcel Mapping for Urban Development
 client: The Providence Plan
-date: 2011-12-15
+date: 2011-04-11
+end: 2012-01-06
 links:
   source: https://github.com/oddbird/mlt
 tasks:

--- a/content/work/medcurbside.md
+++ b/content/work/medcurbside.md
@@ -5,8 +5,8 @@ image:
   src: work/medcurbside/medcurbside.jpg
   alt: Ask or answer medical questions
 client: &client Lab06
-date: 2016-01-01
-end: 2017-12-15
+date: 2016-02-01
+end: 2018-03-01
 links:
   site: https://www.medcurbside.com/
 tags:

--- a/content/work/metadeploy.md
+++ b/content/work/metadeploy.md
@@ -9,8 +9,7 @@ image:
   src: work/metadeploy/metadeploy.jpg
   alt: App UI of product installation flow
 client: &client Salesforce.org
-date: 2018-01-01
-end: 2019-05-15
+date: 2018-05-31
 tags:
   - Technology Sector
 people:

--- a/content/work/metecho.md
+++ b/content/work/metecho.md
@@ -4,7 +4,7 @@ title: Metecho (preview)
 sub: Collaboration for Salesforce projects
 logo: salesforce
 client: &client Salesforce.org
-date: 2020-05-15
+date: 2019-03-21
 people:
   - &jason
     name: Jason Lantz

--- a/content/work/mozdev.md
+++ b/content/work/mozdev.md
@@ -5,7 +5,7 @@ image:
   src: mozdev/mozilla-youtube.jpg
 logo: mozilla
 client: Mozilla
-date: 2019-10-01
+date: 2019-07-01
 end: 2020-01-06
 links:
   youtube: https://www.youtube.com/MozillaDeveloper

--- a/content/work/moztrap.md
+++ b/content/work/moztrap.md
@@ -6,8 +6,8 @@ image:
   alt: Tabular data showing recent software test results
 logo: mozilla
 client: Mozilla
-date: 2011-01-01
-end: 2012-03-15
+date: 2010-11-12
+end: 2012-10-11
 links:
   source: https://github.com/mozilla/moztrap
 tags:

--- a/content/work/phamaly.md
+++ b/content/work/phamaly.md
@@ -3,7 +3,8 @@ title: Phamaly Theatre Website
 sub: Built with WordPress
 logo: phamaly
 client: Phamaly
-date: 2019-12-06
+date: 2019-08-01
+end: 2021-03-02
 image:
   src: work/phamaly/chicago.jpg
   alt: Phamaly cast performing Chicago

--- a/content/work/portfoliyo.md
+++ b/content/work/portfoliyo.md
@@ -3,7 +3,8 @@ eleventyExcludeFromCollections: true
 title: Portfoliyo
 sub: Real-Time Communication for Parents, Teachers, and Students
 client: The K Network
-date: 2013-05-15
+date: 2012-07-13
+end: 2014-01-06
 links:
   source: https://github.com/oddbird/portfoliyo
 tasks:
@@ -15,4 +16,3 @@ summary: |
   Centralized communication for teachers, students, and parents --
   without relying on a computer in every home.
 ---
-

--- a/content/work/quarqnet.md
+++ b/content/work/quarqnet.md
@@ -10,8 +10,8 @@ image:
   src: work/quarqnet/quarqnet-hero.jpg
   alt: World's greatest athlete, Stacy Kvernmo's latest bike ride stats and mapped route
 client: SRAM/Quarq
-date: 2015-01-01
-end: 2016-12-15
+date: 2015-09-02
+end: 2017-01-31
 tags:
   - _post
   - Case Study

--- a/content/work/quarqrace.md
+++ b/content/work/quarqrace.md
@@ -9,8 +9,8 @@ image:
   src: work/quarqrace/trig.jpg
   alt: Athlete list tied to their location and elevation
 client: SRAM/Quarq
-date: 2015-01-01
-ends: 2016-12-15
+date: 2015-09-01
+end: 2017-01-31
 tags:
   - Sports Sector
   - Wellness Sector

--- a/content/work/second-measure.md
+++ b/content/work/second-measure.md
@@ -7,7 +7,7 @@ image:
   src: work/second-measure/secondmeasure.jpg
   alt: UI component library color palette options grouped by category
 client: &client Second Measure
-date: 2019-03-29
+date: 2019-01-22
 end: 2020-12-15
 tags:
   - Analytics Sector

--- a/content/work/steelwheels.md
+++ b/content/work/steelwheels.md
@@ -2,7 +2,8 @@
 eleventyExcludeFromCollections: true
 title: The Steel Wheels
 client: The Steel Wheels
-date: 2010-05-15
+date: 2009-11-01
+end: 2011-03-31
 tasks:
 summary: |
   The official website of The Steel Wheels.

--- a/content/work/streams.md
+++ b/content/work/streams.md
@@ -3,7 +3,8 @@ eleventyExcludeFromCollections: true
 title: Streams Resource Library
 sub: Curation Tools for Teachers
 client: Junyo
-date: 2014-09-15
+date: 2013-05-09
+end: 2015-03-01
 tasks:
   - Product Branding
   - User Experience Design

--- a/content/work/timedesigner.md
+++ b/content/work/timedesigner.md
@@ -4,7 +4,6 @@ sub: Whole-School Design Thinking & Scheduling
 logo: tegy
 client: &client Tegy
 date: 2017-01-11
-end: 2018-07-15
 image:
   src: work/timedesigner/grid-desktop.jpg
   alt: School schedule grid

--- a/content/work/timedesigner.md
+++ b/content/work/timedesigner.md
@@ -3,7 +3,7 @@ title: TimeDesigner
 sub: Whole-School Design Thinking & Scheduling
 logo: tegy
 client: &client Tegy
-date: 2016-01-01
+date: 2017-01-11
 end: 2018-07-15
 image:
   src: work/timedesigner/grid-desktop.jpg

--- a/content/work/trop.md
+++ b/content/work/trop.md
@@ -5,7 +5,8 @@ sub: A cool little lit mag from Los Angeles.
 image:
   src: work/trop/trop.jpg
 client: &client Trop Magazine
-date: 2017-01-15
+date: 2016-05-01
+end: 2017-01-31
 links:
   site: https://tropmag.com/
 press:

--- a/content/work/workflow-builder.md
+++ b/content/work/workflow-builder.md
@@ -3,8 +3,8 @@ title: Workflow Builder
 sub: Tools for data analytics
 logo: aunalytics
 client: &client Aunalytics
-date: 2019-01-13
-end: 2020-01-13
+date: 2019-11-01
+end: 2020-01-31
 image:
   src: work/workflow-builder/workflow.jpg
   alt: Connected workflow processes shown within the canvas


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&soc)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->



## Description

- The `Work Samples` list should be sorted by end date (grouped by client). 

- Ongoing items should appear at the top of the work samples list. 

- This PR also changes the prefixes for ongoing client work items:
    For posts, items in a list of posts/tags, and the list of work samples, client dates take the 'since' prefix if they are ongoing.





## Steps to test/reproduce
- Navigate to the `/work/` page and note the sorting order of the first sample from each client. 
- The list should be in order of the end date in descending order, grouped by client. 
- If a work sample has no end date, it should come in descending order compared to the end or start date of its nearest sample. 

For items that end in the same year, use the work sample file to double check order. 

_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
