### PR TITLE
Fix the hero type-flag on small screens

### DIFF
--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -18,12 +18,12 @@
   --clip-overlap: var(--gutter);
 
   grid-template:
-    'hero type' auto
-    'title hero2' var(--clip-overlap)
-    'title .' auto
-    'meta meta' auto
-    'intro intro' auto
-    / auto minmax(var(--edge), 1fr);
+    'hero type type' auto
+    'title title hero2' var(--clip-overlap)
+    'title title .' auto
+    'meta meta meta' auto
+    'intro intro intro' auto
+    / auto auto minmax(var(--edge), 1fr);
 
   #title {
     padding-left: var(--page-margin);


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&hero-flag)


## Description
Uncomment if you want to provide a custom description.

While I was working on adding an announcement for AEA Denver, I noticed this bug cutting off our 'post-type flag' on small screens.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

- go to a resource with a type flag (such as the linkedin learning interview)
- resize the browser

## Show me
_Provide screenshots/animated gifs/videos if necessary._

![Screen Shot 2022-06-07 at 1 30 35 PM](https://user-images.githubusercontent.com/104161/172466888-c39076ed-230e-430f-a736-e17073e68bee.jpg)
![Screen Shot 2022-06-07 at 1 30 05 PM](https://user-images.githubusercontent.com/104161/172466891-899dcd5f-9f0a-4c55-bf80-3f3960d8a51f.jpg)

