### PR TITLE
Fix confusing u-url, and add explicit syndication links

### DIFF
--- a/content/_includes/birds.macros.njk
+++ b/content/_includes/birds.macros.njk
@@ -84,12 +84,10 @@ params:
   page=none,
   link=true,
   fullname=true,
-  class=none,
-  hcard=true
+  class=none
 ) -%}
-  {%- set hclass = 'h-card p-name' if hcard else 'p-name' -%}
-  {%- set hclass = [hclass, 'u-url'] | join(' ') if link else hclass -%}
   {%- set page = collections.birds | authorPage(name) if (collections and not page) else page -%}
+  {%- set class = ['h-card', class] | join(' ') if class else 'h-card' -%}
   {%- if page.data -%}
     {%- set all = 'OddBird' if (name == 'oddbird') else none -%}
     {%- set bird = page.data.title if fullname else (page.data.shortname or name | capitalize) -%}
@@ -97,9 +95,9 @@ params:
     {{ utility.link_if(
       content=name | mdInline | safe,
       url=page.url if link else none,
-      class=[hclass, class] | join(' ') if class else hclass
-    ) }}
+      class=class
+    ) }}</span>
   {%- else -%}
-    {{ name | capitalize }}
+    <span {{ utility.attr_if('class', class) }}>{{ name | capitalize }}</span>
   {%- endif -%}
 {%- endmacro %}

--- a/content/_includes/birds.macros.njk
+++ b/content/_includes/birds.macros.njk
@@ -96,7 +96,7 @@ params:
       content=name | mdInline | safe,
       url=page.url if link else none,
       class=class
-    ) }}</span>
+    ) }}
   {%- else -%}
     <span {{ utility.attr_if('class', class) }}>{{ name | capitalize }}</span>
   {%- endif -%}

--- a/content/_includes/page/base.njk
+++ b/content/_includes/page/base.njk
@@ -24,4 +24,10 @@
     {{ content | typogr | safe }}
     {% include "page/list.njk" %}
   </div>
+
+  <!-- used for webmentions -->
+  <a href="{{ page.url | url }}" class="u-url" hidden>{{ full_title | safe }}</a>
+  {% for link in syndication %}
+    <a rel="syndication" class="u-syndication" href="{{ link | url }}" hidden>{{ link | url }}</a>
+  {% endfor %}
 </main>

--- a/content/_includes/page/base.njk
+++ b/content/_includes/page/base.njk
@@ -26,7 +26,7 @@
   </div>
 
   <!-- used for webmentions -->
-  <a href="{{ page.url | url }}" class="u-url" hidden>{{ full_title | safe }}</a>
+  <a href="{{ page.url | url }}" class="u-url" hidden>{{ (banner or title) | mdInline | safe }}</a>
   {% for link in syndication %}
     <a rel="syndication" class="u-syndication" href="{{ link | url }}" hidden>{{ link | url }}</a>
   {% endfor %}

--- a/content/blog/2022/100-percent-test-coverage.md
+++ b/content/blog/2022/100-percent-test-coverage.md
@@ -2,6 +2,8 @@
 title: What's the impact of aiming for 100% test coverage?
 author: olu
 date: 2022-06-08
+syndication:
+  - https://twitter.com/oluoluoxenfree/status/1534612562796494850
 tags:
   - Article
   - Testing

--- a/content/blog/2022/dependabot-single-pull-request.md
+++ b/content/blog/2022/dependabot-single-pull-request.md
@@ -49,11 +49,11 @@ to upgrade dependencies at our convenience.
 Broadly speaking, the workflow will:
 
 1. Checkout our code
-2. Configure the runtimes required by our project (Python and Node)
-3. Run a custom command to upgrade all dependencies
-4. Use git to detect changed files
-5. Commit the changes to a pre-defined branch (if they exist)
-6. Open a pull request for that branch (if it doesn't exist already)
+1. Configure the runtimes required by our project (Python and Node)
+1. Run a custom command to upgrade all dependencies
+1. Use git to detect changed files
+1. Commit the changes to a pre-defined branch (if they exist)
+1. Open a pull request for that branch (if it doesn't exist already)
 
 This workflow should be compatible with most projects, but you will need to
 adjust steps two and three to run your own commands depending on what package

--- a/content/blog/2022/dependabot-single-pull-request.md
+++ b/content/blog/2022/dependabot-single-pull-request.md
@@ -2,6 +2,8 @@
 title: Replace Dependabot With a Single Dependency Upgrade Pull Request
 author: ed
 date: 2022-06-01
+syndication:
+  - https://twitter.com/OddBird/status/1532795655076339712
 tags:
   - Article
   - Build Tools
@@ -47,11 +49,11 @@ to upgrade dependencies at our convenience.
 Broadly speaking, the workflow will:
 
 1. Checkout our code
-1. Configure the runtimes required by our project (Python and Node)
-1. Run a custom command to upgrade all dependencies
-1. Use git to detect changed files
-1. Commit the changes to a pre-defined branch (if they exist)
-1. Open a pull request for that branch (if it doesn't exist already)
+2. Configure the runtimes required by our project (Python and Node)
+3. Run a custom command to upgrade all dependencies
+4. Use git to detect changed files
+5. Commit the changes to a pre-defined branch (if they exist)
+6. Open a pull request for that branch (if it doesn't exist already)
 
 This workflow should be compatible with most projects, but you will need to
 adjust steps two and three to run your own commands depending on what package

--- a/content/blog/2022/shared-elements.md
+++ b/content/blog/2022/shared-elements.md
@@ -3,6 +3,8 @@ title: Every Transition is a Page Transition?
 sub: Experimenting with the shared element transitions API
 author: miriam
 date: 2022-06-29
+syndication:
+  - https://twitter.com/OddBird/status/1542535314366902277
 tags:
   - Article
   - CSS

--- a/src/mentions/webmentions.json
+++ b/src/mentions/webmentions.json
@@ -1,6 +1,50 @@
 {
-  "lastFetched": "2022-06-29T20:00:24.285Z",
+  "lastFetched": "2022-06-30T19:19:56.079Z",
   "children": [
+    {
+      "type": "entry",
+      "author": {
+        "type": "card",
+        "name": "Mia (not her best work)",
+        "photo": "https://webmention.io/avatar/pbs.twimg.com/0070719556938ae95053b104df74ca15213d4a99abb84c5e03fe27b0c52e139e.jpg",
+        "url": "https://twitter.com/TerribleMia"
+      },
+      "url": "https://twitter.com/TerribleMia/status/1542572293117071360",
+      "published": "2022-06-30T18:14:28+00:00",
+      "wm-received": "2022-06-30T18:49:14Z",
+      "wm-id": 1425458,
+      "wm-source": "https://brid.gy/comment/twitter/oddbird/1542535314366902277/1542572293117071360",
+      "wm-target": "https://www.oddbird.net/2022/06/29/shared-elements/",
+      "content": {
+        "html": "This was all sparked by a demo video <a href=\"https://twitter.com/jaffathecake\">@jaffathecake</a> released last month, and then an edge-case <a href=\"https://twitter.com/jh3yy\">@jh3yy</a> suggested, a visualization of Cascade Layers, and an inspiring talk on 'impossible' animations from <a href=\"https://twitter.com/cassiecodes\">@cassiecodes</a>. Put it all together, and…\n<a class=\"u-mention\" href=\"https://twitter.com/OddBird\"></a>\n<a class=\"u-mention\" href=\"https://www.oddbird.net/2022/06/29/shared-elements/\"></a>",
+        "text": "This was all sparked by a demo video @jaffathecake released last month, and then an edge-case @jh3yy suggested, a visualization of Cascade Layers, and an inspiring talk on 'impossible' animations from @cassiecodes. Put it all together, and…"
+      },
+      "in-reply-to": "https://www.oddbird.net/2022/06/29/shared-elements/",
+      "wm-property": "in-reply-to",
+      "wm-private": false
+    },
+    {
+      "type": "entry",
+      "author": {
+        "type": "card",
+        "name": "Johannes Odland 🏳️‍🌈",
+        "photo": "https://webmention.io/avatar/pbs.twimg.com/a9882e9b684f606ecedd1f140e7a763e553db6b6aa60ce95cc34869979926210.jpg",
+        "url": "https://twitter.com/mrodland"
+      },
+      "url": "https://twitter.com/mrodland/status/1542544240865157122",
+      "published": "2022-06-30T16:23:00+00:00",
+      "wm-received": "2022-06-30T16:48:19Z",
+      "wm-id": 1425400,
+      "wm-source": "https://brid.gy/comment/twitter/oddbird/1542535314366902277/1542544240865157122",
+      "wm-target": "https://www.oddbird.net/2022/06/29/shared-elements/",
+      "content": {
+        "html": "I find this approach interesting, but would it work if there are other elements like tooltips above the transitioning elements, or if there are other animations, videos or interactions running while the transition takes place?\n\nI’m dreaming of an element transition api 😀\n<a class=\"u-mention\" href=\"https://twitter.com/OddBird\"></a>\n<a class=\"u-mention\" href=\"https://twitter.com/TerribleMia\"></a>\n<a class=\"u-mention\" href=\"https://www.oddbird.net/2022/06/29/shared-elements/\"></a>",
+        "text": "I find this approach interesting, but would it work if there are other elements like tooltips above the transitioning elements, or if there are other animations, videos or interactions running while the transition takes place?\n\nI’m dreaming of an element transition api 😀"
+      },
+      "in-reply-to": "https://www.oddbird.net/2022/06/29/shared-elements/",
+      "wm-property": "in-reply-to",
+      "wm-private": false
+    },
     {
       "type": "entry",
       "author": {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&syn)


## Description

- simplified author `h-card` to avoid `u-url` confusion
- added hidden `u-url` and optional `u-syndication` links to pages
- added syndication links to several recent articles

## Steps to test/reproduce

- use https://indiewebify.me/validate-h-entry/ to test the h-entry data from recent posts
- if you test on the live site, you'll see it treats the author url as the post url, which is the main bug being fixed here