### PR TITLE
[safari-img-bug] fill image container in Safari in offset grid

### DIFF
--- a/src/scss/patterns/_offset-grid.scss
+++ b/src/scss/patterns/_offset-grid.scss
@@ -55,6 +55,7 @@ $break: 'wide-break';
 
   img {
     flex: 1 0 auto;
+    height: 100%;
     object-fit: cover;
   }
 }


### PR DESCRIPTION
## Description
In Safari on the Services page, the images for each service did not fill their container. 

## Steps to test/reproduce
go to /services and view images

## Show me
![safair-bug](https://github.com/oddbird/oddleventy/assets/1581694/b62ee403-1ded-450d-91e0-9dbfc014b4b9)

now: 
![safari-bug-fix](https://github.com/oddbird/oddleventy/assets/1581694/0efa0c1d-238b-4802-b884-b9f4911fd4e3)
