### PR TITLE
make sure post thumbs are same height

### DIFF
--- a/src/scss/components/_post.scss
+++ b/src/scss/components/_post.scss
@@ -19,7 +19,10 @@
   grid-area: post;
   grid-row-gap: var(--shim);
   grid-template:
-    [hero-start] 'left type type' auto
+    [hero-start] 'left type type' var(
+      --post-thumb-height,
+      var(--post-thumb-small)
+    )
     [hero-end] 'left main right' 1fr
     / [hero-start] var(--post-margin) minmax(min-content, var(--page)) var(
       --post-margin
@@ -69,8 +72,9 @@
 }
 
 [data-post='large'] {
-  --post-margin: minmax(0, 1fr);
   --item-title: var(--h2);
+  --post-margin: minmax(0, 1fr);
+  --post-thumb-height: auto;
 }
 
 // Elements

--- a/src/scss/config/scale/_theme-sizes.scss
+++ b/src/scss/config/scale/_theme-sizes.scss
@@ -6,3 +6,4 @@ $logo-item: 10rem;
 $grid-item: 16rem;
 $main-min: calc(100vw - var(--page-margin) * 2);
 $extra: calc((var(--wide-page) - var(--page)) / 2);
+$post-thumb-small: 6rem;


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&sdfghjkmn)



## Description
Some image ratios will end up looking shorter in our post lists. This will fix that by giving all thumbs a fixed height.



## Steps to test/reproduce
Compare the Winging it post on the [live site homepage](https://oddbird.net) to [this deploy preview](https://deploy-preview-454--oddleventy.netlify.app/) (or see screenshots) 
Compare the [live site's 2022 "State of CSS Frameworks"](https://oddbird.net/blog/2/) post thumb in the post list to the one [in this preview](https://deploy-preview-454--oddleventy.netlify.app/blog/2/) (or see screenshots)


## Show me

Post List Before
![post-list-before](https://github.com/oddbird/oddleventy/assets/1581694/14fba2c0-7d66-4a9e-990c-fd8c7eea47f9)

Post List After
![post-list-after](https://github.com/oddbird/oddleventy/assets/1581694/cd6eb783-bcff-406b-ab7b-4845f54944a8)


Before
![home-before](https://github.com/oddbird/oddleventy/assets/1581694/57b22c39-1681-4a75-8512-5da04adb37a2)

After
![home-after](https://github.com/oddbird/oddleventy/assets/1581694/508ee9c1-80b5-4017-81a0-c84c2c2179b8)
