### PR TITLE
Make highlighted resource post types plural

### DIFF
--- a/content/tags/index.njk
+++ b/content/tags/index.njk
@@ -21,7 +21,11 @@ summary: |
 {% macro show(item, collections) %}
   <article {{ post.aria_label(item, 'tag') }}>
     {%- set item_title -%}
+     {% if item.type and not (item.tag == 'Winging It') %}
+      {{- item.type.plural -}}
+     {%- else -%}
       {{- item.tag -}}
+     {% endif %}
       <span class="sr-only">tag</span>
     {%- endset -%}
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->


## Steps to test/reproduce

Navigate to `/tags/` and see the highlighted resource types at the top of the list

_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me

![image](https://github.com/oddbird/oddleventy/assets/41588129/22e200d8-9c76-4b57-b6dd-d4745f2a04cb)

_Provide screenshots/animated gifs/videos if necessary._
