### PR TITLE
Do we need to elide summaries, or can we summarize them?

### DIFF
--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -268,15 +268,8 @@ params:
           {{ talks.list(post | pageEvents, compact=true, show_links=false) }}
         </div>
       {% elif post.data.summary %}
-        {% set summary = post.data.summary | md %}
         <div class="p-summary">
-          {% if (card == 'large') %}
-            {{ summary | safe }}
-          {% else %}
-            <p>
-              {{ summary | safe }}
-            </p>
-          {% endif %}
+          {{ post.data.summary | md | safe }}
         </div>
       {% endif %}
     </div>

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -268,8 +268,15 @@ params:
           {{ talks.list(post | pageEvents, compact=true, show_links=false) }}
         </div>
       {% elif post.data.summary %}
+        {% set summary = post.data.summary | md %}
         <div class="p-summary">
-          {{ post.data.summary | md | safe }}
+          {% if (card == 'large') %}
+            {{ summary | safe }}
+          {% else %}
+            <p>
+              {{ summary | elide | safe }}
+            </p>
+          {% endif %}
         </div>
       {% endif %}
     </div>

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -274,7 +274,7 @@ params:
             {{ summary | safe }}
           {% else %}
             <p>
-              {{ summary | elide | safe }}
+              {{ summary | safe }}
             </p>
           {% endif %}
         </div>

--- a/content/blog/2022/platform-tools.md
+++ b/content/blog/2022/platform-tools.md
@@ -42,11 +42,10 @@ tags:
   - Fonts
   - Design
 summary: |
-  > Ask not just: _How well does it work_?
-  > But also: _How well does it fail_?
-  > What happens when something goes wrong?
-  >
-  > ---Jeremy Keith
+  "Ask not just: _How well does it work_?
+  But also: _How well does it fail_?
+  What happens when something goes wrong?"
+  ---Jeremy Keith
 ---
 
 {% import "embed.macros.njk" as embed %}

--- a/content/services/design-systems.md
+++ b/content/services/design-systems.md
@@ -9,8 +9,8 @@ action:
   text: Talk with us »
   url: /contact/
 summary: |
-  **We partner with clients
-  to build design systems**
+  We partner with clients
+  to build design systems
   that improve team communication,
   speed up development,
   and lay the foundation

--- a/content/services/development.md
+++ b/content/services/development.md
@@ -10,16 +10,20 @@ action:
   text: See work samples »
   url: /work/
 summary: |
-  **We integrate design and development in an agile process**, so you only need
-  to hire one team – completely focused on achieving your goals with smooth and
-  efficient progress from concept to launch and beyond. Starting from user
-  needs, we collaborate with you to deliver usable features quickly and
-  efficiently.
+  We integrate design and development in an agile process,
+  so you only need to hire one team
+  focused on achieving your goals
+  from concept to launch and beyond.
+  Starting from user needs,
+  we collaborate with you to deliver usable features
+  quickly and efficiently.
 
-  We provide expertise across a range of technologies, including
+  We provide expertise in UX & UI design,
+  and a range of technologies including
+  accessible **HTML** and **CSS/Sass**,
   **Python** with **Django** & **FastAPI**,
-  accessible **HTML**, **CSS/Sass**,
-  **JavaScript** with **React** & **Vue**, **Node**, and more.
+  **JavaScript** with **React**/**Vue**/**Svelte**,
+  **Node**, and more.
 ---
 
 {% import 'embed.macros.njk' as embed %}

--- a/content/services/index.njk
+++ b/content/services/index.njk
@@ -30,7 +30,7 @@ summary: |
         <header class="post-header">
           {{ post.banner(page, level=2) }}
         </header>
-          <p>{{ page.data.summary | md | elide | safe }}</p>
+          <p>{{ page.data.summary | md | safe }}</p>
         </div>
       </div>
     </article>

--- a/content/services/index.njk
+++ b/content/services/index.njk
@@ -30,7 +30,7 @@ summary: |
         <header class="post-header">
           {{ post.banner(page, level=2) }}
         </header>
-          <p>{{ page.data.summary | md | safe }}</p>
+          {{ page.data.summary | md | safe }}
         </div>
       </div>
     </article>

--- a/content/services/planning.md
+++ b/content/services/planning.md
@@ -163,31 +163,30 @@ action:
   text: Schedule a call to begin
   url: /contact/
 summary: |
-  **Most projects start with Research & Concepting**
+  Most projects start with Research & Concepting
   to make sure we thoroughly understand your project.
-  We'll help you pinpoint the right digital product --
+  Using an object-oriented user experience (OOUX) strategy,
+  we'll help you pinpoint the right digital product --
   with interactive wireframes,
   prioritized estimates,
   and a robust plan for development and launch.
-
-  Using an object-oriented user experience strategy (OOUX) --
-  popularized by [Sophia Prater] --
-  we'll guide you through a
-  process to define the concepts or
-  "objects" that make up your web app,
-  the relationships between those objects,
-  and the ways users want to interact with those objects.
-  We will deliver an Object Map
-  to streamline communication
-  between designers, developers, and stakeholders
-  throughout the project.
-
-  [Sophia Prater]: https://www.ooux.com/
-
 ---
 
 {% import 'quotes.macros.njk' as quotes %}
 {% import 'embed.macros.njk' as embed %}
+
+We'll guide you through the
+Object Oriented User Experience (OOUX) process --
+popularized by [Sophia Prater] --
+to define the "objects" that make up your web app,
+the relationships between those objects,
+and the ways users want to interact with those objects.
+We will deliver an Object Map
+to streamline communication
+between designers, developers, and stakeholders
+throughout the project.
+
+[Sophia Prater]: https://www.ooux.com/
 
 {{ quotes.find(
   collections.all,

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -39,9 +39,7 @@ summary: |
               [years, item.data.sub] | join(' -- ')
             ) }}
           </header>
-          <p>
-            {{ item.data.summary | md | safe }}
-          </p>
+          {{ item.data.summary | md | safe }}
         </div>
         {% if (show == 'details') %}
           {%- set context -%}

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -40,7 +40,7 @@ summary: |
             ) }}
           </header>
           <p>
-            {{ item.data.summary | md | elide | safe }}
+            {{ item.data.summary | md | safe }}
           </p>
         </div>
         {% if (show == 'details') %}

--- a/src/scss/patterns/_blockquotes.scss
+++ b/src/scss/patterns/_blockquotes.scss
@@ -4,22 +4,24 @@ blockquote {
   --edge: minmax(var(--page-margin), 1fr);
   --quote: minmax(min-content, var(--page));
 
-  background-color: var(--callout);
-  display: grid;
   margin: var(--newline) 0;
-  object-fit: cover;
-  padding: var(--spacer) 0;
 
-  &:nth-of-type(odd) {
-    @include layout.clip('right');
+  &:not([data-card] *) {
+    background-color: var(--callout);
+    display: grid;
+    padding: var(--spacer) 0;
 
-    grid: 'edge icon quote' auto / var(--edge) auto var(--quote);
-  }
+    &:nth-of-type(odd) {
+      @include layout.clip('right');
 
-  &:nth-of-type(even) {
-    @include layout.clip('left');
+      grid: 'edge icon quote' auto / var(--edge) auto var(--quote);
+    }
 
-    grid: 'icon quote edge' auto / auto var(--quote) var(--edge);
+    &:nth-of-type(even) {
+      @include layout.clip('left');
+
+      grid: 'icon quote edge' auto / auto var(--quote) var(--edge);
+    }
   }
 
   .u-photo {
@@ -34,7 +36,7 @@ blockquote {
     margin-inline-start: calc(50% - 50vw);
   }
 
-  &:not([data-quote]) {
+  &:not([data-quote]):not([data-card] *) {
     &::before {
       color: var(--icon);
       content: '“';
@@ -59,7 +61,7 @@ blockquote {
 // -------------
 
 [data-quote='solo'],
-blockquote:not([data-quote]) {
+blockquote:not([data-quote]):not([data-card] *) {
   &:nth-of-type(odd) {
     --column: full / wide;
 

--- a/src/scss/patterns/_blockquotes.scss
+++ b/src/scss/patterns/_blockquotes.scss
@@ -4,24 +4,21 @@ blockquote {
   --edge: minmax(var(--page-margin), 1fr);
   --quote: minmax(min-content, var(--page));
 
+  background-color: var(--callout);
+  display: grid;
   margin: var(--newline) 0;
+  padding: var(--spacer) 0;
 
-  &:not([data-card] *) {
-    background-color: var(--callout);
-    display: grid;
-    padding: var(--spacer) 0;
+  &:nth-of-type(odd) {
+    @include layout.clip('right');
 
-    &:nth-of-type(odd) {
-      @include layout.clip('right');
+    grid: 'edge icon quote' auto / var(--edge) auto var(--quote);
+  }
 
-      grid: 'edge icon quote' auto / var(--edge) auto var(--quote);
-    }
+  &:nth-of-type(even) {
+    @include layout.clip('left');
 
-    &:nth-of-type(even) {
-      @include layout.clip('left');
-
-      grid: 'icon quote edge' auto / auto var(--quote) var(--edge);
-    }
+    grid: 'icon quote edge' auto / auto var(--quote) var(--edge);
   }
 
   .u-photo {
@@ -36,7 +33,7 @@ blockquote {
     margin-inline-start: calc(50% - 50vw);
   }
 
-  &:not([data-quote]):not([data-card] *) {
+  &:not([data-quote]) {
     &::before {
       color: var(--icon);
       content: '“';
@@ -61,7 +58,7 @@ blockquote {
 // -------------
 
 [data-quote='solo'],
-blockquote:not([data-quote]):not([data-card] *) {
+blockquote:not([data-quote]) {
   &:nth-of-type(odd) {
     --column: full / wide;
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&hidden)

## Description
Uncomment if you want to provide a custom description.

- Remove the `elide` filter on summaries
- Try to shorten some real long summaries on services
- Looking at post summaries, I also tried to fix the blockquote summary layout

## Related Issue(s)
_Reminder to add related issue(s), if available._

- #534 

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

This was used in three places

- post lists
- work samples
- services
