### PR TITLE
Style updates

### DIFF
--- a/src/scss/config/color/_content.scss
+++ b/src/scss/config/color/_content.scss
@@ -3,6 +3,8 @@ $text-light: var(--ccs-neutral--fg3);
 $accent: var(--ccs-accent--fg1);
 $highlight: var(--ccs-accent--fg3);
 $feature: var(--ccs-prime--fg4);
+$heading-start: var(--ccs-prime--fg2);
+$heading-end: var(--ccs-accent--fg2);
 $border: var(--ccs-neutral);
 $border-fade: var(--ccs-neutral--fade);
 $shadow: hsla(var(--ccs-h--neutral), var(--ccs-s--fg6), var(--ccs-l--fg6), 40%);

--- a/src/scss/config/scale/_theme-sizes.scss
+++ b/src/scss/config/scale/_theme-sizes.scss
@@ -4,6 +4,6 @@ $radius: var(--half-shim);
 $grid-hero: calc(var(--gutter) * 8);
 $logo-item: 10rem;
 $grid-item: 16rem;
-$main-min: calc(100vw - var(--page-margin) * 2);
+$main-min: min-content;
 $extra: calc((var(--wide-page) - var(--page)) / 2);
 $post-thumb-small: 6rem;

--- a/src/scss/config/scale/_theme-sizes.scss
+++ b/src/scss/config/scale/_theme-sizes.scss
@@ -4,6 +4,5 @@ $radius: var(--half-shim);
 $grid-hero: calc(var(--gutter) * 8);
 $logo-item: 10rem;
 $grid-item: 16rem;
-$main-min: min-content;
 $extra: calc((var(--wide-page) - var(--page)) / 2);
 $post-thumb-small: 6rem;

--- a/src/scss/initial/_headings.scss
+++ b/src/scss/initial/_headings.scss
@@ -20,12 +20,28 @@ h6 {
   --link: currentcolor;
 
   margin-bottom: 0;
+  text-wrap: balance;
 }
 
 h1,
 h2 {
   line-height: 1.2;
   margin: var(--gutter-plus) 0 var(--newline);
+}
+
+h2,
+h3 {
+  @supports (background-clip: text) or (-webkit-background-clip: text) {
+    background: linear-gradient(
+      to bottom right,
+      var(--heading-start),
+      var(--heading-end)
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    max-width: max-content;
+  }
 }
 
 h3,

--- a/src/scss/initial/_scale.scss
+++ b/src/scss/initial/_scale.scss
@@ -16,14 +16,13 @@ html {
   @include config.sizes--;
 
   --page-columns: [full-start] var(--page-margin) [content-start wide-start
-    page-start] minmax(var(--main-min), var(--page)) [page-end wide-end
-    content-end] var(--page-margin) [full-end];
+    page-start] minmax(0, var(--page)) [page-end wide-end content-end]
+    var(--page-margin) [full-end];
 
   @include config.above('wide-page') {
-    --main-min: var(--min-page);
     --page-columns: [full-start] var(--page-margin) [content-start]
       minmax(0, 1fr) [wide-start] minmax(0, var(--extra)) [page-start]
-      minmax(var(--main-min), var(--page)) [page-end] minmax(0, var(--extra))
+      minmax(min-content, var(--page)) [page-end] minmax(0, var(--extra))
       [wide-end] minmax(0, 1fr) [content-end] var(--page-margin) [full-end];
   }
 }

--- a/src/scss/initial/_type.scss
+++ b/src/scss/initial/_type.scss
@@ -52,6 +52,7 @@ span:where(.h-card):not(.p-org) {
 p {
   margin-bottom: var(--newline);
   margin-top: 0;
+  text-wrap: pretty;
 
   &:empty {
     display: none;

--- a/src/scss/layout/_main.scss
+++ b/src/scss/layout/_main.scss
@@ -21,4 +21,8 @@
   & > & {
     grid-column: full;
   }
+
+  @media (min-width: 45ch) {
+    --inline-bleed: calc(var(--gutter) * -1);
+  }
 }

--- a/src/scss/patterns/_code.scss
+++ b/src/scss/patterns/_code.scss
@@ -24,15 +24,10 @@ pre {
   background: var(--bg-full);
   border: thin solid var(--border);
   color: var(--text);
-  contain: inline-size;
   padding: var(--gutter);
-  margin: var(--newline) var(--pre-inline-pull, 0);
+  margin: var(--newline) var(--inline-bleed, 0);
   overflow: auto;
   white-space: pre;
-
-  @media (min-width: 45ch) {
-    --pre-inline-pull: calc(var(--gutter) * -1);
-  }
 }
 
 code:not([class^='language']) {

--- a/src/scss/patterns/_code.scss
+++ b/src/scss/patterns/_code.scss
@@ -15,9 +15,7 @@ code {
   line-height: 1.5;
   tab-size: 2;
   text-align: left;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: normal;
+  overflow-wrap: break-word;
 }
 
 pre {
@@ -36,7 +34,6 @@ code:not([class^='language']) {
   color: var(--highlight);
   padding-left: var(--quarter-shim);
   padding-right: var(--quarter-shim);
-  overflow-wrap: anywhere;
 }
 
 .token.comment,

--- a/src/scss/patterns/_code.scss
+++ b/src/scss/patterns/_code.scss
@@ -24,10 +24,15 @@ pre {
   background: var(--bg-full);
   border: thin solid var(--border);
   color: var(--text);
+  contain: inline-size;
   padding: var(--gutter);
-  margin: var(--newline) calc(var(--gutter) * -1);
+  margin: var(--newline) var(--pre-inline-pull, 0);
   overflow: auto;
   white-space: pre;
+
+  @media (min-width: 45ch) {
+    --pre-inline-pull: calc(var(--gutter) * -1);
+  }
 }
 
 code:not([class^='language']) {
@@ -36,6 +41,7 @@ code:not([class^='language']) {
   color: var(--highlight);
   padding-left: var(--quarter-shim);
   padding-right: var(--quarter-shim);
+  overflow-wrap: anywhere;
 }
 
 .token.comment,

--- a/src/scss/patterns/_dropdown.scss
+++ b/src/scss/patterns/_dropdown.scss
@@ -50,7 +50,7 @@
   background: var(--bg);
   border: thin solid var(--active);
   box-shadow: 0 0 var(--quarter-shim) var(--shadow);
-  max-width: calc(100vw - var(--page-margin) * 2);
+  max-width: calc(100% - var(--page-margin) * 2);
   min-width: 14em;
   position: absolute;
 

--- a/src/scss/patterns/_sections.scss
+++ b/src/scss/patterns/_sections.scss
@@ -146,7 +146,7 @@
   }
 
   > * {
-    max-width: calc(100vw - var(--page-margin));
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&break)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Related Issue(s)
_Reminder to add related issue(s), if available._

- Fixes #542 
- Fixes #543 (design in #538)

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

Best I can tell, the overflow issue was caused by using `100vw`, which doesn't account for scrollbars. If you set scrollbars to 'always visible' in your OS settings, it's easier to see a before/after without going through the link copy/paste process. Before: the grid continues behind the scrollbar. After: the grid ends at the scrollbar.

Since overflow-x is set to `hidden`, it can only be scrolled programatically. That's what the link trick achieves - offsetting the otherwise un-scrollable x axis to fit the entire heading. In other words: long headings don't cause the overflow, but links to long headings make it more visible. 

Changing the grid to use `0` as the grid min instead seems to work pretty well. All the block stuff resizes to fit. I did see the Sass pkg post overflowing still, because of a long `code` element. That's why I added `overflow-wrap: break-word` to code elements. It will still only wrap if it doesn't fit on a line. 

## Show me
_Provide screenshots/animated gifs/videos if necessary._
![Screenshot 2024-03-22 at 2 30 48 PM](https://github.com/oddbird/oddleventy/assets/104161/4c765827-94a5-4b6c-b434-5257f2a075d2)
![Screenshot 2024-03-22 at 2 31 31 PM](https://github.com/oddbird/oddleventy/assets/104161/e09f355a-6008-4ac6-9f18-70607917a990)
