### PR TITLE
[winging-it-6b] quick capitalization fix for episode 6 outline

### DIFF
--- a/content/blog/wingingit/winging-it-06.md
+++ b/content/blog/wingingit/winging-it-06.md
@@ -37,7 +37,7 @@ summary: |
 - What is state?
 - State management solutions
 - What are Proxies?
-- When and How to use Proxies to manage state
+- When and how to use Proxies to manage state
 - When to avoid using Proxiess for state management
 - Proxies in the real world
 

--- a/content/blog/wingingit/winging-it-06.md
+++ b/content/blog/wingingit/winging-it-06.md
@@ -38,7 +38,7 @@ summary: |
 - State management solutions
 - What are Proxies?
 - When and how to use Proxies to manage state
-- When to avoid using Proxiess for state management
+- When to avoid using Proxies for state management
 - Proxies in the real world
 
 ## Links:


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&oops)

## Description
Quick fix for outline

## The Problem
![Screenshot 2024-04-18 at 4 31 22 PM](https://github.com/oddbird/oddleventy/assets/1581694/b795c6ef-4141-43b0-8a37-0a46ac2f8245)

## The Solution
![Screenshot 2024-04-18 at 4 38 01 PM](https://github.com/oddbird/oddleventy/assets/1581694/fb083e61-5d78-4eb8-9ea3-a11108b5637d)

(I also removed the second s on `Proxiess` in the line under the `When and how`)