### PR TITLE
 Add different styles for code blocks inside callouts

### DIFF
--- a/src/scss/patterns/_callout.scss
+++ b/src/scss/patterns/_callout.scss
@@ -1,5 +1,6 @@
 [data-callout] {
   --list-padding--default: 1em;
+  --inline-bleed: var(--gutter);
 
   background: var(--callout-block-bg, var(--callout));
   border-inline-start: thick solid var(--callout-block-border, var(--border));

--- a/src/scss/patterns/_callout.scss
+++ b/src/scss/patterns/_callout.scss
@@ -1,6 +1,6 @@
 [data-callout] {
   --list-padding--default: 1em;
-  --inline-bleed: var(--gutter);
+  --inline-bleed: 0;
 
   background: var(--callout-block-bg, var(--callout));
   border-inline-start: thick solid var(--callout-block-border, var(--border));


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->

## Related Issue(s)
fixes #581 
_Reminder to add related issue(s), if available._


## Steps to test/reproduce

go to /2014/06/14/sqlalchemy-postgres-autocommit/ and look at the codeblocks inside of callouts
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me

![bild](https://github.com/oddbird/oddleventy/assets/41588129/1b728c8c-dacd-4b3a-953c-abfb312914b5)

_Provide screenshots/animated gifs/videos if necessary._
