### PR TITLE
Add registration fallback link

### DIFF
--- a/content/workshops/cascading-layouts.md
+++ b/content/workshops/cascading-layouts.md
@@ -73,11 +73,11 @@ summary: |
       (tito.q = tito.q || []).push(arguments);
     };
   tito('on:widget:loaded',function(){
-     document.getElementById('fallback-link').setAttribute('hidden', 'hidden');
+     document.getElementById('tito-registration-fallback').setAttribute('hidden', 'hidden');
   });
 </script>
 
-<a href="https://ti.to/pland/css-layout" id="fallback-link">Register</a>
+<a href="https://ti.to/pland/css-layout" id="tito-registration-fallback">Register</a>
 <tito-widget event="pland/css-layout"></tito-widget>
 
 ## What Will Attendees Learn In This Workshop?

--- a/content/workshops/cascading-layouts.md
+++ b/content/workshops/cascading-layouts.md
@@ -67,6 +67,17 @@ summary: |
 ## Register Now
 
 <script src="https://js.tito.io/v2" async></script>
+<script>
+  window.tito = window.tito ||
+    function() {
+      (tito.q = tito.q || []).push(arguments);
+    };
+  tito('on:widget:loaded',function(){
+     document.getElementById('fallback-link').setAttribute('hidden', 'hidden');
+  });
+</script>
+
+<a href="https://ti.to/pland/css-layout" id="fallback-link">Register</a>
 <tito-widget event="pland/css-layout"></tito-widget>
 
 ## What Will Attendees Learn In This Workshop?


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&fallback)

## Description
Adds a fallback registration link until the Tito Widget is fully loaded.

## Steps to test/reproduce
1. Go to Registration page - https://deploy-preview-627--oddleventy.netlify.app/workshops/cascading-layouts/
2. Enable Throttling in your Network dev tools
3. Load the registration page, see there is a Registration link that gets removed once the widget is fully loaded.

