### PR TITLE
Add Favicon link

### DIFF
--- a/content/_layouts/base.njk
+++ b/content/_layouts/base.njk
@@ -28,6 +28,9 @@
     <link rel="webmention" href="https://webmention.io/www.oddbird.net/webmention" />
     <link rel="pingback" href="https://webmention.io/www.oddbird.net/xmlrpc" />
 
+    {# Favicon #}
+    <link rel="icon" href="/favicon.ico">
+
     {% if perma %}
       <link rel="canonical"
         href="{{ perma }}">


### PR DESCRIPTION
## Description
I noticed our logo was not appearing in Google search results.

<img width="655" alt="image" src="https://github.com/user-attachments/assets/2542694b-bf1e-48cc-959a-5ee714671574">

 While we are serving a favicon at `https://oddbird.net/favicon.ico`, there isn't a `link` in the header. Per [Google's docs](https://developers.google.com/search/docs/appearance/favicon-in-search), we should have a link.

## Steps to test/reproduce
Verify the favicon still works. After deployment, we should check Google Search results and verify it works.