### PR TITLE
Talk details for JS Heroes

### DIFF
--- a/content/birds/miriam.md
+++ b/content/birds/miriam.md
@@ -24,11 +24,6 @@ events:
     url: https://smashingconf.com/ny-2025
     date: 2025-10-06
     end: 2025-10-09
-  - venue: JS Heroes
-    adr: Cluj, Romania
-    url: https://jsheroes.io/
-    date: 2025-05-29
-    end: 2025-05-30
   - venue: CSS Day
     adr: Amsterdam, NL
     url: https://cssday.nl/2024

--- a/content/talks/cascading-layers.md
+++ b/content/talks/cascading-layers.md
@@ -15,6 +15,11 @@ tags:
   - CSSWG
 slides: https://slides.oddbird.net/layers/
 events:
+  - venue: JS Heroes
+    adr: Cluj, Romania
+    url: https://jsheroes.io/
+    date: 2025-05-29
+    end: 2025-05-30
   - venue: An Event Apart
     adr: San Francisco, CA
     date: 2022-12-12


### PR DESCRIPTION
## Description

Move the JS Heroes event details to the correct talk description, now that it's decided. 
