### PR TITLE
Keep work sample images from overflowing mobile screen svgs

### DIFF
--- a/content/_includes/embed.macros.njk
+++ b/content/_includes/embed.macros.njk
@@ -298,6 +298,7 @@ params:
   fit=none,
   position=none,
   notch='15%',
+  inset='5px',
   content=none
 ) %}
   {%- set content = content if (content != none) else caller() -%}
@@ -305,7 +306,8 @@ params:
     '--device-img-notch': notch,
     '--device-img-fill': fill,
     '--device-img-fit': fit,
-    '--device-img-position': position
+    '--device-img-position': position,
+    '--device-clip-inset': inset
   } -%}
   <div data-screen="{{ device }}" {{ utility.style_if(style) }}>
     {{ content | safe }}

--- a/content/_includes/embed.macros.njk
+++ b/content/_includes/embed.macros.njk
@@ -291,6 +291,12 @@ params:
     type: html
     default: none
     note: The image to embed (can also be passed into a `caller()` block)
+  inset:
+    type: number
+    default: 5px
+    note: |
+      Number used to specify size of the clip-path of the image inside
+      of the screen
 #}
 {% macro screen(
   device='iphone',

--- a/content/oddnews.njk
+++ b/content/oddnews.njk
@@ -42,6 +42,7 @@ summary: |
   {{ embed.media_block(
     media=embed.screen(
       notch='5%',
+      inset='7px',
       content=embed.img(
         src='writing/pexels-frank-cone.jpg',
         alt='An orange hummingbird flying in the air',

--- a/content/work/coachhub.md
+++ b/content/work/coachhub.md
@@ -136,6 +136,7 @@ escalation of care.
 {% call embed.media_block(
   media=embed.screen(
     notch='5%',
+    inset='2%',
     content=embed.img(
       src='work/coachhub/coachhub-phone.jpg',
       alt='list of coaches with location, specialty, and

--- a/src/scss/patterns/_devices.scss
+++ b/src/scss/patterns/_devices.scss
@@ -10,7 +10,7 @@
 
   img {
     background: var(--device-img-fill, white);
-    clip-path: inset(2px round var(--device-radius, 0));
+    clip-path: inset(5px round var(--device-radius, 0));
     height: 100%;
     inset: 1px;
     object-fit: var(--device-img-fit, cover);

--- a/src/scss/patterns/_devices.scss
+++ b/src/scss/patterns/_devices.scss
@@ -10,7 +10,9 @@
 
   img {
     background: var(--device-img-fill, white);
-    clip-path: inset(5px round var(--device-radius, 0));
+    clip-path: inset(
+      var(--device-clip-inset, 5px) round var(--device-radius, 0)
+    );
     height: 100%;
     inset: 1px;
     object-fit: var(--device-img-fit, cover);
@@ -23,6 +25,10 @@
     position: absolute;
     width: 100%;
     z-index: -1;
+  }
+
+  .oddnews-intro & {
+    --device-radius: calc(0.3rem * 2);
   }
 }
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->

## Related Issue(s)
Fixes #832 
_Reminder to add related issue(s), if available._


## Steps to test/reproduce
Look at images shown in the iphone frame we use for work samples. These are mostly on the detailed work pages, the main site header, and the OddNews index page. (Test in dark and light modes)
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me

### Hire Us CTA

before (see bottom right):
![image](https://github.com/user-attachments/assets/8e160f79-2848-42c4-ae0e-9b4d914bf577)

after:
![image](https://github.com/user-attachments/assets/08417ed4-0133-44d4-8579-6a153891c4c2)

### Main site header

before (see bottom):
![image](https://github.com/user-attachments/assets/efdd38c5-048b-4a17-b652-f53e848b8cc5)
 
after:
![image](https://github.com/user-attachments/assets/f756f595-60de-4fc2-a76b-fedec472908a)


### Adobe:
before (bottom right)
![image](https://github.com/user-attachments/assets/85c795ed-8452-4848-ba90-032250c89ce1)

after
![image](https://github.com/user-attachments/assets/6d955b43-9680-4850-869b-c2cf40ce28c9)


### CFO Share
before (see bottom):
![image](https://github.com/user-attachments/assets/9d82f32a-dd6e-4ef4-a3de-d7e1fdaffb58)

after:
![image](https://github.com/user-attachments/assets/6a38df02-0f48-4753-9487-40141c14cb40)



### quarq race
before:
![image](https://github.com/user-attachments/assets/f9a37d3d-481a-460b-bf6b-9855502006f9)

after
![image](https://github.com/user-attachments/assets/06a2b09a-6860-45d8-8478-46430819bd00)

_Provide screenshots/animated gifs/videos if necessary._
