### PR TITLE
Clean up oddnews macro

### DIFF
--- a/content/_data/taxonomy.yaml
+++ b/content/_data/taxonomy.yaml
@@ -21,6 +21,9 @@ post:
   - tag: Winging It
     icon: winging-it-lines
     plural: Episodes
+  - tag: Course
+    icon: mail-open
+    plural: Courses
 
 oss:
   - title: Open Web

--- a/content/_includes/oddnews.macros.njk
+++ b/content/_includes/oddnews.macros.njk
@@ -9,9 +9,13 @@ label: oddnews_signup
 note: Generate an OddNews signup form
 params:
   heading:
-    type: boolean
+    type: boolean | string
     default: true
-    note: Whether to include the "OddNews Sign Up" heading
+    note: Whether to include the "OddNews Sign Up" heading, or a custom heading
+  subheading:
+    type: boolean | string
+    default: true
+    note: Whether to include default subheading, or a custom subheading
   tag:
     type: string
     default: 'footer'
@@ -27,21 +31,21 @@ params:
 #}
 {% macro oddnews_signup(
   heading=true,
+  subheading=true,
   tag='footer',
   class=none,
-  buttonText='Subscribe',
-  altHeading=false,
-  altSubheading=none
+  buttonText='Subscribe'
 ) %}
   <div class="oddnews-signup{% if class %} {{ class }}{% endif %}">
-    {%- if heading and altHeading -%}
-     <h3>{{ altHeading }}</h3>
-     <p>{{ altSubheading }}</p>
-      {% else %}
-        {%- if heading -%}
-          <h3>OddNews Sign Up</h3>
+    {%- if heading -%}
+      <h3>{{ heading if heading | typeCheck('string') else 'OddNews Sign Up' }}</h3>
+      {%- if subheading -%}
+        {%- if subheading | typeCheck('string') -%}
+          <p>{{ subheading }}</p>
+        {%- else -%}
           <p>Get the latest news in front-end development — CSS, HTML, JavaScript, and UX. <a href="/oddnews">See Archive</a></p>
         {%- endif -%}
+      {%- endif -%}
     {%- endif -%}
 
     <form action="https://oddbird.us19.list-manage.com/subscribe/post?u=80219aa68d7bad77b9fd2eb93&amp;id=7c27f7fb9a&amp;f_id=000a9de4f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self">

--- a/content/learn/courses/anchor-positioning.md
+++ b/content/learn/courses/anchor-positioning.md
@@ -13,7 +13,7 @@ extended: |
   or to [refactor your existing application](/contact/).
 action:
   text: Subscribe now
-  url: "#sign-up"
+  url: '#sign-up'
 image:
   src: blog/2024/anchor1.jpg
   alt: A rusty anchor hanging with the sea in the background.
@@ -26,7 +26,7 @@ press:
       so I could get it working in Firefox.
     slug: shout-out
     name: Luke Hansford
-    venue: "@lukehansford@mastodon.social"
+    venue: '@lukehansford@mastodon.social'
     url: https://mastodon.social/@lukehansford
     face: luke-hansford-bg.jpg
   - text: |
@@ -61,9 +61,9 @@ summary: |
   of the browser spec, and will stand the test of time.
 ---
 
-{% import "layout.macros.njk" as layout %}
-{% import "quotes.macros.njk" as quotes %}
-{% import "birds.macros.njk" as birds %}
+{% import 'layout.macros.njk' as layout %}
+{% import 'quotes.macros.njk' as quotes %}
+{% import 'birds.macros.njk' as birds %}
 {% import 'embed.macros.njk' as embed %}
 {% import 'utility.macros.njk' as utility %}
 {% import 'oddnews.macros.njk' as oddnews %}
@@ -233,12 +233,11 @@ possibilities for innovative layouts.
 {% call layout.block('column') %}
 
 {{ oddnews.oddnews_signup(
-  heading=true,
-  tag="course-anchor-positioning",
-  class="headerless",
-  buttonText="Subscribe",
-  altHeading="Email Course Sign Up",
-  altSubheading="Be among the first to discover new layout possibilities with anchor positioning."
+  heading='Email Course Sign Up',
+  subheading='Be among the first to discover new layout possibilities with anchor positioning.',
+  tag='course-anchor-positioning',
+  class='headerless',
+  buttonText='Subscribe'
 ) }}
 
 {% endcall %}

--- a/content/learn/courses/courses.11tydata.yaml
+++ b/content/learn/courses/courses.11tydata.yaml
@@ -1,0 +1,2 @@
+tags:
+  - Course

--- a/test/js/taxonomy.test.js
+++ b/test/js/taxonomy.test.js
@@ -22,6 +22,7 @@ describe('fromTaxonomy', () => {
       { tag: 'Case Study', icon: 'tools', plural: 'Case Studies' },
       { tag: 'Article', icon: 'news', plural: 'Articles' },
       { tag: 'Winging It', icon: 'winging-it-lines', plural: 'Episodes' },
+      { tag: 'Course', icon: 'mail-open', plural: 'Courses' },
     ];
 
     expect(fromTaxonomy('post', { icon: 'news' })).toEqual({


### PR DESCRIPTION
A continuation of #821 and #826.

I think this still needs navigation to make the email course accessible/findable, and a new icon/taxonomy? See https://github.com/oddbird/oddleventy/pull/826#pullrequestreview-2791764056