### PR TITLE
hotfix: fix .offset-media images on Services and Work pages

### DIFF
--- a/src/scss/patterns/_offset-grid.scss
+++ b/src/scss/patterns/_offset-grid.scss
@@ -46,7 +46,7 @@ $break: 'wide-break';
   }
 }
 
-// services page
+// services and work pages
 
 .offset-media {
   --offset-media-padding: 0;
@@ -54,7 +54,7 @@ $break: 'wide-break';
   display: flex;
 
   img {
-    flex: 1 0 auto;
+    flex: 1;
     height: 100%; // Safari fix
     object-fit: cover;
   }


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->

## Related Issue(s)
fixes #896 
_Reminder to add related issue(s), if available._


## Steps to test/reproduce
- view the services and work list pages in the latest version of Chrome. images should be the correct size
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me

### Services page before:

![image](https://github.com/user-attachments/assets/04d80707-f2aa-4563-b379-f1a739159552)

![image](https://github.com/user-attachments/assets/ce9f08a8-278a-4867-85d6-bcb678038f7c)

### Services page after

![image](https://github.com/user-attachments/assets/09f0eccb-260d-484b-a304-e2f8f9ddc547)

### Work page before

![image](https://github.com/user-attachments/assets/0564479c-4585-4085-a904-a9b76a794ba0)


### Work page after
![image](https://github.com/user-attachments/assets/57568743-a109-4d35-bfbe-95fc303b2296)




_Provide screenshots/animated gifs/videos if necessary._
