### PR TITLE
hotfix: remove typo in OddContrast article

### DIFF
--- a/content/blog/2025/oddcontrast-guide.md
+++ b/content/blog/2025/oddcontrast-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Make the Web a More a Colorful Place!
+title: Make the Web a More Colorful Place!
 sub: A guide to using new color spaces & formats with OddContrast
 author: oddbird
 date: 2025-06-06


### PR DESCRIPTION



## Description
There was an extra "a" in the headline. 



## Steps to test/reproduce
see [/2025/06/06/oddcontrast-guide/](https://deploy-preview-911--oddleventy.netlify.app/2025/06/06/oddcontrast-guide/)
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me
![image](https://github.com/user-attachments/assets/832fec5c-c85a-438d-b71e-82e2cef00749)

_Provide screenshots/animated gifs/videos if necessary._
