### PR TITLE
Add link to email course

### DIFF
--- a/content/blog/2024/anchor-position-polyfill-2.md
+++ b/content/blog/2024/anchor-position-polyfill-2.md
@@ -119,6 +119,12 @@ default, the polyfill parses all of your CSS, which is likely more than you
 need. You're now able to specify exactly which CSS stylesheets contain rules
 that impact how you use anchor positioning, so not all CSS has to be parsed.
 
+{% callout 'note', false %}
+Interested in learning more about anchor positioning?
+Sign up for our free weekly
+[CSS anchor positioning email course](/learn/courses/anchor-positioning).
+{% endcallout %}
+
 ## Coming soon
 
 What are you excited for with anchor positioning? We'd love to implement

--- a/content/blog/2024/anchor-position-polyfill.md
+++ b/content/blog/2024/anchor-position-polyfill.md
@@ -126,6 +126,12 @@ have a different layout, where you want `#target-b` to anchor to a
 }
 ```
 
+{% callout 'note', false %}
+Interested in learning more about anchor positioning?
+Sign up for our free weekly
+[CSS anchor positioning email course](/learn/courses/anchor-positioning).
+{% endcallout %}
+
 ## What's next?
 
 While a lot of the basic functionality is already possible with the polyfill,

--- a/content/blog/2024/anchor-position-yearbook.md
+++ b/content/blog/2024/anchor-position-yearbook.md
@@ -173,6 +173,12 @@ As an added bonus, because the photo and name are in the same `<li>`, we can add
 hover effects so that if one is hovered, both parts are hovered. If the item is
 a link they can be inside the same `<a>`.
 
+{% callout 'note', false %}
+Interested in learning more about anchor positioning?
+Sign up for our free weekly
+[CSS anchor positioning email course](/learn/courses/anchor-positioning).
+{% endcallout %}
+
 ## Wrap-up
 
 What new possibilities for anchor positioning are you excited about? Let us know

--- a/content/blog/2025/anchor-position-area.md
+++ b/content/blog/2025/anchor-position-area.md
@@ -204,6 +204,12 @@ yet support `position-area`. This article was written as part of our exploration
 into the spec, and if you would like to sponsor further development, please
 [get in touch](/contact/)!
 
+{% callout 'note', false %}
+Interested in learning more about anchor positioning?
+Sign up for our free weekly
+[CSS anchor positioning email course](/learn/courses/anchor-positioning).
+{% endcallout %}
+
 ## Sponsor us
 
 If you found this article helpful, please [sponsor our

--- a/content/blog/2025/anchor-position-validity.md
+++ b/content/blog/2025/anchor-position-validity.md
@@ -322,6 +322,12 @@ containing blocks. Is there a way we could move this from a set of guidelines
 and a checklist of gotchas to avoid, to a place where these rules click and make
 sense to developers?
 
+{% callout 'note', false %}
+Interested in learning more about anchor positioning?
+Sign up for our free weekly
+[CSS anchor positioning email course](/learn/courses/anchor-positioning).
+{% endcallout %}
+
 ## Sponsor us
 
 If you found this article helpful, please [sponsor our

--- a/content/blog/2025/polyfill-updates.md
+++ b/content/blog/2025/polyfill-updates.md
@@ -160,6 +160,12 @@ Anchor Positioning. You can follow [that
 issue](https://github.com/oddbird/css-anchor-positioning/issues/91) to find out
 more.
 
+{% callout 'note', false %}
+Interested in learning more about anchor positioning?
+Sign up for our free weekly
+[CSS anchor positioning email course](/learn/courses/anchor-positioning).
+{% endcallout %}
+
 ## Can you help?
 
 Over the last few months, we've enjoyed the chance to make a lot of updates to


### PR DESCRIPTION
## Description

Adds note with link to the email course from:

/2025/05/06/polyfill-updates/
/2025/02/25/anchor-position-area/
/2025/01/29/anchor-position-validity/
/2024/11/18/anchor-position-yearbook/
/2024/11/12/anchor-position-polyfill-2/
/2024/07/02/anchor-position-polyfill/

These have Winging it CTAs at the top already. I added the email course to the bottom, figuring people are more likely to act at the end than at the beginning.

I did not add it to the Winging it or Learn with Jason pages- it seemed CTA heavy already, but should it still be there?

## Related Issue(s)
https://github.com/oddbird/oddFlock/issues/275


## Show me
<img width="984" alt="image" src="https://github.com/user-attachments/assets/23f29022-d0d7-42db-9712-b5e36fbf2deb" />
