### PR TITLE
Add related posts

### DIFF
--- a/content/_includes/page/base.njk
+++ b/content/_includes/page/base.njk
@@ -59,13 +59,13 @@
     </section>
   {% endif %}
 
+  {% include 'page/list.njk' %}
+
   {% if cta == 'hire' %}
     {% include 'site/hire-us.njk' %}
   {% elif cta == 'sponsor' -%}
     {% include 'site/sponsor-us.njk' %}
   {% endif %}
-
-  {% include 'page/list.njk' %}
 
   <!-- used for webmentions -->
   <a href="{{ page.url | url }}" class="u-url" hidden>{{ (banner or title) | removeMd }}</a>

--- a/content/_includes/page/list.njk
+++ b/content/_includes/page/list.njk
@@ -44,5 +44,10 @@
     collections.all | getCollectionItem(page) | pageEvents
   ) }}
 {% elif is_entry %}
-  {% include 'page/recents.njk' %}
+  {% if related_tag %}
+    {% include 'page/related.njk' %}
+  {% else %}
+    {% include 'page/recents.njk' %}
+  {% endif %}
+
 {% endif %}

--- a/content/_includes/page/list.njk
+++ b/content/_includes/page/list.njk
@@ -49,5 +49,4 @@
   {% else %}
     {% include 'page/recents.njk' %}
   {% endif %}
-
 {% endif %}

--- a/content/_includes/page/recents.njk
+++ b/content/_includes/page/recents.njk
@@ -1,6 +1,6 @@
 {%- set post_type = tags | pageType('tag') -%}
 
-{% if post_type and collections[post_type] | length %}
+{% if post_type and collections[post_type] | removePage(page.url) | length %}
   <section data-list="tag" data-typeset>
     {{ post.recent_posts(
       post_type,

--- a/content/_includes/page/related.njk
+++ b/content/_includes/page/related.njk
@@ -1,0 +1,11 @@
+{%- set tag = related_tag -%}
+
+{% if tag %}
+  <section data-list="tag" data-typeset data-type="{{ tag }}">
+    {{ post.related_posts(
+      tag,
+      collections,
+      page_url=page.url
+    ) }}
+  </section>
+{% endif %}

--- a/content/_includes/page/related.njk
+++ b/content/_includes/page/related.njk
@@ -1,6 +1,6 @@
 {%- set tag = related_tag -%}
 
-{% if tag %}
+{% if tag and collections[tag] | removePage(page.url) | length %}
   <section data-list="tag" data-typeset>
     {{ post.related_posts(
       tag,

--- a/content/_includes/page/related.njk
+++ b/content/_includes/page/related.njk
@@ -1,7 +1,7 @@
 {%- set tag = related_tag -%}
 
 {% if tag %}
-  <section data-list="tag" data-typeset data-type="{{ tag }}">
+  <section data-list="tag" data-typeset>
     {{ post.related_posts(
       tag,
       collections,

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -74,7 +74,8 @@ params:
     default: 3
   banner_title:
     type: string
-    default: 'Related Posts'
+    default: ''
+    note: If set, will override the default title of "Related {tag} Posts"
   page_url:
     type: url
     default: "''"
@@ -83,17 +84,18 @@ params:
   tag,
   collections=[],
   limit=3,
-  banner_title='Related Posts',
+  banner_title=none,
   page_url=''
 ) %}
   {%- set posts = collections[tag] -%}
   {%- if posts | length -%}
-    {%- set recents = posts | pageYears | reverse | removePage(page_url) | onlyShow(limit) -%}
-    {%- if recents | length -%}
+    {%- set related = posts | pageYears | isPublicType | reverse | removePage(page_url) | onlyShow(limit) -%}
+    {%- set title = banner_title or ['Related', tag, 'Posts'] | join(' ') -%}
+    {%- if related | length -%}
       {{ list(
-        recents,
+        related,
         collections=collections,
-        title=banner_title,
+        title=title,
         override_feature=true,
         override_large=true
       ) }}

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -90,7 +90,7 @@ params:
   {%- set posts = collections[tag] -%}
   {%- if posts | length -%}
     {%- set related = posts | pageYears | isPublicType | reverse | removePage(page_url) | onlyShow(limit) -%}
-    {%- set title = banner_title or ['Related', tag, 'Posts'] | join(' ') -%}
+    {%- set title = banner_title or [tag, 'Posts'] | join(' ') -%}
     {%- if related | length -%}
       {{ list(
         related,

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -57,6 +57,51 @@ params:
 
 
 {# @docs
+label: related_posts
+category: lists
+note: |
+  Returns a given number of most recent
+  posts with a tag
+params:
+  tag:
+    type: string
+    note: The tag to show related posts for
+  collections:
+    type: 11ty collections object
+    default: '[]'
+  limit:
+    type: number
+    default: 3
+  banner_title:
+    type: string
+    default: 'Related Posts'
+  page_url:
+    type: url
+    default: "''"
+#}
+{% macro related_posts(
+  tag,
+  collections=[],
+  limit=3,
+  banner_title='Related Posts',
+  page_url=''
+) %}
+  {%- set posts = collections[tag] -%}
+  {%- if posts | length -%}
+    {%- set recents = posts | pageYears | reverse | removePage(page_url) | onlyShow(limit) -%}
+    {%- if recents | length -%}
+      {{ list(
+        recents,
+        collections=collections,
+        title=banner_title,
+        override_feature=true,
+        override_large=true
+      ) }}
+    {%- endif -%}
+  {%- endif -%}
+{% endmacro %}
+
+{# @docs
 label: recent_posts
 category: lists
 note: |

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -75,7 +75,7 @@ params:
   banner_title:
     type: string
     default: ''
-    note: If set, will override the default title of "{tag} Posts"
+    note: If set, will override the default title of "Posts about {tag}"
   page_url:
     type: url
     default: "''"
@@ -90,7 +90,7 @@ params:
   {%- set posts = collections[tag] -%}
   {%- if posts | length -%}
     {%- set related = posts | pageYears | isPublicType | reverse | removePage(page_url) | onlyShow(limit) -%}
-    {%- set title = banner_title or [tag, 'Posts'] | join(' ') -%}
+    {%- set title = banner_title or ['Posts about', tag] | join(' ') -%}
     {%- if related | length -%}
       {{ list(
         related,

--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -75,7 +75,7 @@ params:
   banner_title:
     type: string
     default: ''
-    note: If set, will override the default title of "Related {tag} Posts"
+    note: If set, will override the default title of "{tag} Posts"
   page_url:
     type: url
     default: "''"

--- a/content/blog/2014/sqlalchemy-postgres-autocommit.md
+++ b/content/blog/2014/sqlalchemy-postgres-autocommit.md
@@ -11,6 +11,7 @@ tags:
   - PostgreSQL
   - Transactions
   - Django
+related_tag: Django
 image:
   src: blog/2014/sqlalchemy.jpg
   alt: SQLAlchemy

--- a/content/blog/2021/containerqueries.md
+++ b/content/blog/2021/containerqueries.md
@@ -13,6 +13,7 @@ tags:
   - CSSWG
   - Article
   - Container Queries
+related_tag: Container Queries
 summary: |
   The `@container` query, that elusive feature developers have been requesting
   and proposing for years, has finally made its debut in a browser. Well, sort

--- a/content/blog/2022/cascade-layers-polyfill.md
+++ b/content/blog/2022/cascade-layers-polyfill.md
@@ -8,6 +8,7 @@ tags:
   - Cascade Layers
   - CSSWG
   - Polyfill
+related_tag: Cascade Layers
 image:
   src: blog/2022/postcss-cascade-layers-polyfill.png
   alt: |

--- a/content/blog/2022/headed-playwright-in-docker.md
+++ b/content/blog/2022/headed-playwright-in-docker.md
@@ -7,6 +7,7 @@ tags:
   - Article
   - Testing
   - Docker
+related_tag: Testing
 image:
   src: blog/2022/containers.jpg
   alt: |

--- a/content/blog/2023/sqlalchemy-for-django-developers.md
+++ b/content/blog/2023/sqlalchemy-for-django-developers.md
@@ -10,6 +10,7 @@ tags:
   - Django
   - FastAPI
   - SQLAlchemy
+related_tag: Django
 image:
   src: blog/2023/library.jpg
 summary: |

--- a/content/blog/2024/sass-compiler.md
+++ b/content/blog/2024/sass-compiler.md
@@ -12,6 +12,7 @@ tags:
   - Article
   - Sass
   - Build Tools
+related_tag: Sass
 summary:
   Sass compilation can be a speed bottleneck in your build,
   but it doesn't have to be anymore.

--- a/content/blog/2024/zoomies.md
+++ b/content/blog/2024/zoomies.md
@@ -25,6 +25,7 @@ tags:
   - Article
   - CSS
   - Layout
+related_tag: CSS
 ---
 
 {% import 'embed.macros.njk' as embed %}

--- a/content/blog/2025/anchor-position-area.md
+++ b/content/blog/2025/anchor-position-area.md
@@ -14,6 +14,7 @@ tags:
   - Article
   - Anchor Positioning
   - CSS
+related_tag: Anchor Positioning
 summary: |
   `position-area` might be my favorite part of the CSS Anchor Positioning spec,
   with a ton of features packed in to make things just... work.

--- a/content/blog/2025/anchor-position-validity.md
+++ b/content/blog/2025/anchor-position-validity.md
@@ -13,6 +13,7 @@ tags:
   - Article
   - Anchor Positioning
   - CSS
+related_tag: Anchor Positioning
 summary: |
   It is frustrating to track down why an anchor isn't being found.
   I've found a simple way that should work in most cases.

--- a/content/blog/2025/custom-functions.md
+++ b/content/blog/2025/custom-functions.md
@@ -8,6 +8,7 @@ tags:
   - CSS
   - Layout
   - W3C
+related_tag: CSS
 image:
   src: /projects/w3c.jpg
   alt: >

--- a/content/blog/2025/fluid-type.md
+++ b/content/blog/2025/fluid-type.md
@@ -8,6 +8,7 @@ tags:
   - Article
   - CSS
   - Typography
+related_tag: Typography
 series: revisiting fluid typography
 image:
   src: blog/2025/font-scale-hero.jpg

--- a/content/blog/2025/logical-options.md
+++ b/content/blog/2025/logical-options.md
@@ -18,6 +18,7 @@ tags:
   - CSS
   - CSSWG
   - Logical Properties
+related_tag: CSSWG
 series: CSS logical shorthands
 action:
   text: Sponsor our work on logical shorthands

--- a/content/blog/2025/logical-shorthand.md
+++ b/content/blog/2025/logical-shorthand.md
@@ -11,6 +11,7 @@ tags:
   - CSS
   - CSSWG
   - Logical Properties
+related_tag: CSSWG
 series: CSS logical shorthands
 action:
   text: Sponsor work on logical shorthands

--- a/content/blog/2025/new-features-oddcontrast.md
+++ b/content/blog/2025/new-features-oddcontrast.md
@@ -9,6 +9,8 @@ tags:
   - Color
   - Design
   - OddTools
+  - OddContrast
+related_tag: OddContrast
 image:
   src: blog/2025/oddcontrast-gamut-sliders.png
   alt: >

--- a/content/blog/2025/oddcontrast-guide.md
+++ b/content/blog/2025/oddcontrast-guide.md
@@ -10,6 +10,7 @@ tags:
   - Design
   - OddContrast
   - OddTools
+related_tag: OddContrast
 image:
   src: blog/2025/oddcontrast-guide.jpg
   alt: >

--- a/content/blog/2025/polyfill-updates.md
+++ b/content/blog/2025/polyfill-updates.md
@@ -17,6 +17,7 @@ tags:
   - Anchor Positioning
   - Polyfill
   - CSS
+related_tag: Anchor Positioning
 summary: |
   We have been busy updating the Popover and
   CSS Anchor Positioning Polyfills,

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -126,6 +126,7 @@ export default (eleventyConfig) => {
   eleventyConfig.addFilter('removePage', pages.removePage);
   eleventyConfig.addFilter('addCallToAction', pages.addCallToAction);
   eleventyConfig.addFilter('isType', pages.isType);
+  eleventyConfig.addFilter('isPublicType', pages.isPublicType);
   eleventyConfig.addFilter('isHome', pages.isHome);
 
   eleventyConfig.addFilter('fromTaxonomy', taxonomy.fromTaxonomy);

--- a/src/filters/pages.js
+++ b/src/filters/pages.js
@@ -389,7 +389,10 @@ params:
     note: containing 11ty page objects
 */
 export const isPublicType = (collection) =>
-  collection.filter((page) => tagIsPublic(pageType(page.data.tags, 'tag')));
+  collection.filter((page) => {
+    const type = pageType(page.data.tags, 'tag');
+    return type && tagIsPublic(type);
+  });
 
 /* @docs
 label: isHome

--- a/src/filters/pages.js
+++ b/src/filters/pages.js
@@ -4,6 +4,8 @@ import { pageType } from '#filters/taxonomy.js';
 import { getDate, now } from '#filters/time.js';
 import { getSort } from '#filters/utils.js';
 
+import { isPublic as tagIsPublic } from './tags.js';
+
 /* @docs
 label: Page Filters
 category: File
@@ -373,6 +375,21 @@ params:
 */
 export const isType = (collection, type) =>
   collection.filter((page) => pageType(page.data.tags, 'tag') === type);
+
+/* @docs
+label: isPublicType
+category: Filter
+note: |
+  Filters collection and removes any pages
+  that are of a non-public type.
+  (types are defined in the `taxonomy.yaml` data file)
+params:
+  collection:
+    type: array
+    note: containing 11ty page objects
+*/
+export const isPublicType = (collection) =>
+  collection.filter((page) => tagIsPublic(pageType(page.data.tags, 'tag')));
 
 /* @docs
 label: isHome

--- a/test/js/pages.test.js
+++ b/test/js/pages.test.js
@@ -14,6 +14,7 @@ import {
   isCurrent,
   isHome,
   isPublic,
+  isPublicType,
   isType,
   pageYears,
   removePage,
@@ -26,6 +27,11 @@ describe('page filters', () => {
   test('isPublic', () => {
     expect(isPublic(collection3[0])).toBeTruthy();
     expect(isPublic(collection3[1])).toBeFalsy();
+  });
+
+  test('isPublicType', () => {
+    expect(isPublicType(collection4)).toHaveLength(3);
+    expect(collection4).toHaveLength(4);
   });
 
   test('isCurrent', () => {
@@ -115,8 +121,8 @@ describe('page filters', () => {
     });
 
     test('sorts collection', () => {
-      const slugs = ['test3', 'events', 'test1'];
-      const years = ['2018', '2019', '2040'];
+      const slugs = ['test3', 'events', 'test1', 'talk1'];
+      const years = ['2018', '2019', '2040', '2040'];
       const actual = eventSort(collection4);
 
       expect(actual.map((item) => item.page.fileSlug)).toEqual(slugs);
@@ -124,8 +130,8 @@ describe('page filters', () => {
     });
 
     test('sorts collection including future events', () => {
-      const slugs = ['test3', 'test1', 'events'];
-      const years = ['2018', '2040', '2030'];
+      const slugs = ['test3', 'test1', 'talk1', 'events'];
+      const years = ['2018', '2040', '2040', '2030'];
       const actual = eventSort(collection4, true);
 
       expect(actual.map((item) => item.page.fileSlug)).toEqual(slugs);
@@ -189,7 +195,7 @@ describe('page filters', () => {
   test('isType', () => {
     const filtered = isType(collection4, 'Article');
 
-    expect(collection4).toHaveLength(3);
+    expect(collection4).toHaveLength(4);
     expect(filtered).toHaveLength(1);
   });
 

--- a/test/js/utils.js
+++ b/test/js/utils.js
@@ -266,6 +266,20 @@ export const collection4 = [
   },
   {
     page: {
+      inputPath: './talk1.md',
+      fileSlug: 'talk1',
+      outputPath: './_site/talk1/index.html',
+      url: '/talk1/',
+      date: '2040-01-09T04:10:17.000Z',
+    },
+    data: {
+      title: 'Talk 1',
+      tags: ['_talk'],
+    },
+    content: '<h1>This is my title</h1>\n\n<p>This is content…',
+  },
+  {
+    page: {
       inputPath: './test3.md',
       fileSlug: 'test3',
       outputPath: './_site/test3/index.html',


### PR DESCRIPTION
## Description
Adds a way to add "Related Posts" rather than "Recent Posts".

If a `related_tag` is set, then the most recent posts with a tag are shown. Otherwise, the current "Recent Articles" or "Recent Talks" or "Recent Videos" section will be shown.


**Questions:**

- [x] This is limited to 1 related tag- should this support multiple tags? Not yet
- [x] This shows all post types (Podcast, Talk, Video, Link, Article, etc). This should exclude Talks
- [x] Move element higher


## Related Issue(s)
Closes #920 


## Steps to test/reproduce
View https://deploy-preview-924--oddleventy.netlify.app/2025/05/06/polyfill-updates/, where the 3 most recent items tagged "Anchor Positioning" are shown. 

All other sites still show the "Recent Posts" block instead.