### PR TITLE
Add custom courses page [courses]

### DIFF
--- a/content/learn/index.njk
+++ b/content/learn/index.njk
@@ -1,0 +1,34 @@
+---
+title: Courses
+index: Courses
+sub: Frontend web development course for curious developers
+summary: |
+  Video and email courses for frontend web developers on modern CSS including
+  anchor positioning, grid & subgrid, container queries and more!
+---
+
+{% import 'quotes.macros.njk' as quotes %}
+{% import 'post.macros.njk' as post %}
+
+{{ quotes.find(
+  collections.all,
+  slugs=['unique-talent', 'fits-together']
+) }}
+
+{{ layout.title('All Courses') }}
+
+{% set courses = collections.all | withData('data.tags', 'Course') %}
+{% if courses | length %}
+
+  <section data-list="tag" data-typeset>
+    {{ post.by_year(
+      courses,
+      collections,
+      label=label
+    ) }}
+  </section>
+
+{% else %}
+<p>No courses found.</p>
+{% endif %}
+


### PR DESCRIPTION
![](https://picsum.photos/600/400)

## Description
WIP - Adds custom courses page, the most basic version similar to this mockup: 
[Figma file](https://www.figma.com/design/gJ1cVEGOMRIVgLzB3TMTbQ/Learn-List-Page?node-id=4-91&t=PiTywO01UYbF0V9m-0) 

Eventually, I think we want to go with this [medium term solution](https://www.figma.com/design/gJ1cVEGOMRIVgLzB3TMTbQ/Learn-List-Page?node-id=334-690&t=NkXFmKeKCov4Ll8D-0)

## Related Issue(s)
https://github.com/orgs/oddbird/projects/13/views/5?pane=issue&itemId=101662446&issue=oddbird%7Coddleventy%7C841

## Steps to test/reproduce

