### PR TITLE
Alignment on intros only on posts without hero image

### DIFF
--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -48,7 +48,7 @@
     --edge: 25%;
   }
 
-  &:not(:has([data-flag])) {
+  &:not(:has([data-hero])) {
     --hero-header-justify: start;
     --hero-header-margin-block: var(--double-gutter);
     --post-links-column: 1;


### PR DESCRIPTION
![](https://picsum.photos/600/400)

## Description
Only posts/pages without a hero image should have the starting alignment for the intro and CTA links

## Related Issue(s)
Discussion started in Slack: https://oddbird.slack.com/archives/C02HLQVD1/p1756150272950029

## Steps to test/reproduce
Intro s/b aligned start (left) here: 
https://deploy-preview-964--oddleventy.netlify.app/work/material-repricing/

and centered here:
https://deploy-preview-964--oddleventy.netlify.app/work/
