### PR TITLE
Update calendly link url

### DIFF
--- a/content/services/architecture.md
+++ b/content/services/architecture.md
@@ -209,7 +209,7 @@ and recording the conversation for you.
 
 {{ utility.main_action(
   content='Schedule now »',
-  url='https://calendly.com/oddbirdllc/schedule-a-workshop'
+  url='https://calendly.com/oddbirdllc/css-architecture'
 ) }}
 
 {% endcall %}
@@ -345,7 +345,7 @@ writing, music, and visual art.
 {{ contact.form(
   submit='Send Message',
   name='fixup',
-  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/schedule-a-workshop)'
+  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/css-architecture)'
 ) }}
 
 {% endcall %}

--- a/content/workshops/cascading-layouts.md
+++ b/content/workshops/cascading-layouts.md
@@ -231,7 +231,7 @@ media:
 {{ contact.form(
   submit='Book Now',
   name='workshop',
-  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/schedule-a-workshop)'
+  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/css-architecture)'
 ) }}
 
 ## What Will Attendees Get?
@@ -365,5 +365,5 @@ to talk with your team directly:
 {{ contact.form(
   submit='Book Now',
   name='workshop',
-  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/schedule-a-workshop)'
+  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/css-architecture)'
 ) }}

--- a/content/workshops/cascading-styles-deep.md
+++ b/content/workshops/cascading-styles-deep.md
@@ -118,7 +118,7 @@ summary: |
 {{ contact.form(
   submit='Book Now',
   name='workshop',
-  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/schedule-a-workshop)'
+  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/css-architecture)'
 ) }}
 
 ## What Will Attendees Learn In This Workshop?
@@ -277,5 +277,5 @@ to talk with your team directly:
 {{ contact.form(
   submit='Book Now',
   name='workshop',
-  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/schedule-a-workshop)'
+  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/css-architecture)'
 ) }}

--- a/content/workshops/modern-css.md
+++ b/content/workshops/modern-css.md
@@ -82,7 +82,7 @@ summary: |
 {{ contact.form(
   submit='Book Now',
   name='workshop',
-  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/schedule-a-workshop)'
+  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/css-architecture)'
 ) }}
 
 ## What Will Attendees Learn In This Workshop?
@@ -187,5 +187,5 @@ to talk with your team directly:
 {{ contact.form(
   submit='Book Now',
   name='workshop',
-  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/schedule-a-workshop)'
+  extraActions='or [schedule a call to learn more »](https://calendly.com/oddbirdllc/css-architecture)'
 ) }}


### PR DESCRIPTION
![](https://picsum.photos/600/400?calendar)

## Description

replace https://calendly.com/oddbirdllc/schedule-a-workshop with https://calendly.com/oddbirdllc/css-architecture

but only one can be active at a time, so I want to merge this at the same times as I change it on calendly