### PR TITLE
Redirect poetic-css to oddCourses

### DIFF
--- a/content/_includes/post.macros.njk
+++ b/content/_includes/post.macros.njk
@@ -496,7 +496,7 @@ params:
   } | merge(attrs) -%}
       {{ utility.link_if(
         name,
-        post.page.url,
+        post.data.redirect.to if post.data.redirect else post.page.url,
         'title-link u-url' if hentry else 'title-link'
       ) }}
   {%- endh -%}

--- a/content/courses/poetic-css.md
+++ b/content/courses/poetic-css.md
@@ -20,7 +20,7 @@ summary: |
 author: miriam
 date: 2025-05-30
 permalink: courses/poetic-css/
-canonical: https://courses.oddbird.net/poetic-css
+canonical: https://courses.oddbird.net/poetic-css/
 redirect:
   to: https://courses.oddbird.net/poetic-css/
 ---

--- a/content/courses/poetic-css.md
+++ b/content/courses/poetic-css.md
@@ -20,6 +20,9 @@ summary: |
 author: miriam
 date: 2025-05-30
 permalink: courses/poetic-css/
+canonical: https://courses.oddbird.net/poetic-css
+redirect:
+  to: https://courses.oddbird.net/poetic-css/
 ---
 
 {% import 'layout.macros.njk' as layout %}


### PR DESCRIPTION
![](https://picsum.photos/600/400?redirect)


## Description

Poetic-css course page links redirect to oddCourses.

## Related Issue(s)

https://github.com/oddbird/oddcourses/issues/105

## Steps to test/reproduce

Check out the courses page for a direct link, or go to /courses/poetic-css/ to be redirected.

