### PR TITLE
Restore subdomain redirects (susy, susydocs, susyone, friends, contrast) over HTTPS

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,40 @@
         mainBranch = "main"
         template = "hierarchical"
 
+# Subdomain redirects, migrated from Namecheap URL Forwarding (which cannot
+# serve HTTPS). For each of these to take effect, the subdomain must be added
+# as a domain alias on this Netlify site so Netlify provisions a cert and
+# receives the request. Listed before the path-based rules so host matches win.
+[[redirects]]
+    from = "https://susy.oddbird.net/*"
+    to = "https://www.oddbird.net/susy/"
+    status = 301
+    force = true
+
+[[redirects]]
+    from = "https://susydocs.oddbird.net/*"
+    to = "https://www.oddbird.net/susy/"
+    status = 301
+    force = true
+
+[[redirects]]
+    from = "https://susyone.oddbird.net/*"
+    to = "https://susy.readthedocs.io/susyone/"
+    status = 301
+    force = true
+
+[[redirects]]
+    from = "https://friends.oddbird.net/*"
+    to = "https://www.oddbird.net/"
+    status = 301
+    force = true
+
+[[redirects]]
+    from = "https://contrast.oddbird.net/*"
+    to = "https://www.oddcontrast.com/"
+    status = 301
+    force = true
+
 [[redirects]]
     from = "/accoutrement/docs/*"
     to = "https://accoutrement-docs.netlify.app/accoutrement/docs/:splat"


### PR DESCRIPTION
### Problem
The `*.oddbird.net` subdomain redirects (e.g. `susy.oddbird.net → www.oddbird.net/susy/`) stopped working. They were configured as **Namecheap URL Redirect Records**, which only answer over **HTTP** — as browsers moved to HTTPS-first, requests now hit the dead `https://` endpoint and time out.

Confirmed live:

| Request | Result |
| --- | --- |
| `http://susy.oddbird.net/` | `301 → https://www.oddbird.net/susy/` (`Server: namecheap-nginx`, `X-Served-By: Namecheap URL Forward`) |
| `https://susy.oddbird.net/` | Connection timed out (nothing on :443) |

### Fix
Move the redirects to Netlify, which provisions Let's Encrypt certs for domain aliases and can issue 301s over HTTPS. This PR adds five forced, host-conditional `301` rules to `netlify.toml`, reproducing the exact current destinations:

| Host | → |
| --- | --- |
| `susy.oddbird.net` | `https://www.oddbird.net/susy/` |
| `susydocs.oddbird.net` | `https://www.oddbird.net/susy/` |
| `susyone.oddbird.net` | `https://susy.readthedocs.io/susyone/` |
| `friends.oddbird.net` | `https://www.oddbird.net/` |
| `contrast.oddbird.net` | `https://www.oddcontrast.com/` |

I already made the Netlify and DNS changes, so these subdomains currently serve www.oddbird.net until this PR is merged.

### Notes
- Redirects drop the request path to mirror prior behavior.
- All aliases can live on the `www.oddbird.net` Netlify site even though `contrast`/`susyone` point elsewhere — they just 301 back out.